### PR TITLE
Ensuring logits scores are contiguous resolved the bug on MPS，Mac MPS bug修复

### DIFF
--- a/ChatTTS/utils/infer_utils.py
+++ b/ChatTTS/utils/infer_utils.py
@@ -22,6 +22,7 @@ class CustomRepetitionPenaltyLogitsProcessorRepeat():
         freq = F.one_hot(input_ids, scores.size(1)).sum(1)
         freq[self.max_input_ids:] = 0
         alpha = self.penalty**freq
+        scores = scores.contiguous()
         scores = torch.where(scores < 0, scores*alpha, scores/alpha)
 
         return scores


### PR DESCRIPTION
发现代码在Mac的MPS框架上运行时，效果很差，这是因为CustomRepetitionPenaltyLogitsProcessorRepeat的处理在MPS上，可能会发生score变量数值错误的未知异常，将其连续化scores.contiguous(), 可以解决此问题。