### PR TITLE
Ensuring logits scores are contiguous resolved the bug on MPS

### DIFF
--- a/ChatTTS/utils/infer_utils.py
+++ b/ChatTTS/utils/infer_utils.py
@@ -22,6 +22,7 @@ class CustomRepetitionPenaltyLogitsProcessorRepeat():
         freq = F.one_hot(input_ids, scores.size(1)).sum(1)
         freq[self.max_input_ids:] = 0
         alpha = self.penalty**freq
+        scores = scores.contiguous()
         scores = torch.where(scores < 0, scores*alpha, scores/alpha)
 
         return scores


### PR DESCRIPTION
在Mac的MPS框架上运行代码时，发现性能表现不佳。这是由于CustomRepetitionPenaltyLogitsProcessorRepeat处理在MPS上运行时，导致score变量出现数值错误的异常。将scores变量进行连续内存排布处理，即使用scores.contiguous()方法，可以解决这个问题。