### PR TITLE
Windows not yet supported for torch.compile fix

### DIFF
--- a/ChatTTS/core.py
+++ b/ChatTTS/core.py
@@ -122,7 +122,10 @@ class Chat:
             assert gpt_ckpt_path, 'gpt_ckpt_path should not be None'
             gpt.load_state_dict(torch.load(gpt_ckpt_path))
             if compile and 'cuda' in str(device):
-                gpt.gpt.forward = torch.compile(gpt.gpt.forward,  backend='inductor', dynamic=True)
+                try:
+                    gpt.gpt.forward = torch.compile(gpt.gpt.forward, backend='inductor', dynamic=True)
+                except RuntimeError as e:
+                    logging.warning(f'Compile failed,{e}. fallback to normal mode.')
             self.pretrain_models['gpt'] = gpt
             spk_stat_path = os.path.join(os.path.dirname(gpt_ckpt_path), 'spk_stat.pt')
             assert os.path.exists(spk_stat_path), f'Missing spk_stat.pt: {spk_stat_path}'


### PR DESCRIPTION
Windows not yet supported for torch.compile 
报错位置 ChatTTS->core.py->125:      gpt.gpt.forward = torch.compile(gpt.gpt.forward,  backend='inductor', dynamic=True)
```python
 if compile and 'cuda' in str(device):
                gpt.gpt.forward = torch.compile(gpt.gpt.forward,  backend='inductor', dynamic=True)
```
希望修改为
```python
      if compile and 'cuda' in str(device):
          try:
              gpt.gpt.forward = torch.compile(gpt.gpt.forward, backend='inductor', dynamic=True)
          except RuntimeError as e:
              logging.warning(f'Compile failed,{e}. fallback to normal mode.')
```
以拦截 平台不支持compile 出现RuntimeError 处理方式继续以普通模式运行并打印log输出原因。