### PR TITLE
[Bugfix & Feature] Fix homophones replacer bug and improve output

### DIFF
--- a/ChatTTS/core.py
+++ b/ChatTTS/core.py
@@ -179,9 +179,10 @@ class Chat:
                 self.logger.log(logging.WARNING, f'Invalid characters found! : {invalid_characters}')
                 text[i] = apply_character_map(t)
             if do_homophone_replacement and self.init_homophones_replacer():
-                text[i] = self.homophones_replacer.replace(t)
-                if t != text[i]:
-                    self.logger.log(logging.INFO, f'Homophones replace: {t} -> {text[i]}')
+                text[i], replaced_words = self.homophones_replacer.replace(text[i])
+                if replaced_words:
+                    repl_res = ', '.join([f'{_[0]}->{_[1]}' for _ in replaced_words])
+                    self.logger.log(logging.INFO, f'Homophones replace: {repl_res}')
 
         if not skip_refine_text:
             text_tokens = refine_text(

--- a/ChatTTS/utils/infer_utils.py
+++ b/ChatTTS/utils/infer_utils.py
@@ -76,12 +76,15 @@ class HomophonesReplacer:
 
     def replace(self, text):
         result = []
+        replaced_words = []
         for char in text:
             if char in self.homophones_map:
-                result.append(self.homophones_map[char])
+                repl_char = self.homophones_map[char]
+                result.append(repl_char)
+                replaced_words.append((char, repl_char))
             else:
                 result.append(char)
-        return ''.join(result)
+        return ''.join(result), replaced_words
 
 def count_invalid_characters(s):
     


### PR DESCRIPTION
修复同音替换中的变量使用错误，并更改了替换的输出。

- 原代码在应用字符映射后错误地使用了变量t而不是text[i],会导致前一步 apply_character_map 的结果被覆盖。现已更正此问题。
- 同音字替换的输出改成仅显示替换的字符，使结果更简洁。

原输出：
`Homophones replace:  国有云梦大泽，到处是犀、兕、麋鹿，长江、汉水中的鱼、鳖、鳄鱼天下最丰富，宋国却连野鸡、兔子、狐狸、狸猫都没有，这就像粱肉与 糟糠相比，楚国有松树、梓树、楠木、樟木等名贵木材 -> 国有云梦大泽，到处是犀、四、麋鹿，长江、汉水中的鱼、鳖、鳄鱼天下最丰富，宋国却连野鸡、兔子、狐狸、狸猫都没有，这就像粱肉与 糟糠相比，楚国有松树、子树、楠木、樟木等名贵木材`

修改后：
`Homophones replace: 兕->四, 梓->子`