### PR TITLE
[fix] Adjust GPU memory check threshold

### DIFF
--- a/ChatTTS/core.py
+++ b/ChatTTS/core.py
@@ -95,7 +95,7 @@ class Chat:
         compile: bool = True,
     ):
         if not device:
-            device = select_device(4096)
+            device = select_device(4095)
             self.logger.log(logging.INFO, f'use {device}')
             
         if vocos_config_path:


### PR DESCRIPTION
要求最低显存为4G，实际上4GB显存的GPU被检测为4095.75 MB。现已将阈值调整为4095 MB。

使用 https://github.com/2noise/ChatTTS/blob/main/ChatTTS/utils/gpu_utils.py#L5 检测 NVIDIA GeForce GTX 1650 的显存结果
```
WARNING:ChatTTS.utils.gpu utils:GPU 0 has 4095.75 MB memory left.
```
其他显卡例如：GeForce GTX 1050 Ti 的检测结果也是一样。