### PR TITLE
Disable torch.compile on Windows for webui demo

### DIFF
--- a/examples/web/funcs.py
+++ b/examples/web/funcs.py
@@ -45,10 +45,10 @@ def reload_chat(coef: Optional[str]) -> str:
             gr.Warning("Ingore invalid DVAE coefficient.")
             coef = None
         if custom_path == None:
-            ret = chat.load_models(coef=coef)
+            ret = chat.load_models(coef=coef, compile=sys.platform != 'win32')
         else:
             logger.info('local model path: %s', custom_path)
-            ret = chat.load_models('custom', custom_path=custom_path, coef=coef)
+            ret = chat.load_models('custom', custom_path=custom_path, coef=coef, compile=sys.platform != 'win32')
         if not ret:
             raise gr.Error("Unable to load model.")
         gr.Info("Reload succeess.")

--- a/examples/web/webui.py
+++ b/examples/web/webui.py
@@ -96,10 +96,10 @@ def main():
     global chat
 
     if args.custom_path == None:
-        ret = chat.load_models()
+        ret = chat.load_models(compile=sys.platform != 'win32')
     else:
         logger.info('local model path: %s', args.custom_path)
-        ret = chat.load_models('custom', custom_path=args.custom_path)
+        ret = chat.load_models('custom', custom_path=args.custom_path, compile=sys.platform != 'win32')
 
     if ret:
         logger.info("Models loaded successfully.")


### PR DESCRIPTION
Disable `torch.compile` by default on Windows as it is not supported on Windows yet and gives an unclear error message about z3: https://github.com/pytorch/pytorch/issues/123022