### PR TITLE
refactor: remove unnecessary transpositions

### DIFF
--- a/ChatTTS/model/dvae.py
+++ b/ChatTTS/model/dvae.py
@@ -163,7 +163,7 @@ class DVAEDecoder(nn.Module):
 
         x = self.conv_out(y)
         del y
-        return x.transpose_(1, 2)
+        return x
 
 
 class DVAE(nn.Module):
@@ -214,7 +214,7 @@ class DVAE(nn.Module):
             dec_out = self.out_conv(
                 self.decoder(
                     x=vq_feats,
-                ).transpose_(1, 2),
+                ),
             )
 
             return torch.mul(dec_out, self.coef, out=dec_out)

--- a/ChatTTS/model/dvae.py
+++ b/ChatTTS/model/dvae.py
@@ -154,9 +154,8 @@ class DVAEDecoder(nn.Module):
         )
         self.conv_out = nn.Conv1d(hidden, odim, kernel_size=1, bias=False)
 
-    def forward(self, input: torch.Tensor, conditioning=None) -> torch.Tensor:
-        # B, T, C
-        x = input.transpose_(1, 2)
+    def forward(self, x: torch.Tensor, conditioning=None) -> torch.Tensor:
+        # B, C, T
         y = self.conv_in(x)
         del x
         for f in self.decoder_block:
@@ -214,7 +213,7 @@ class DVAE(nn.Module):
 
             dec_out = self.out_conv(
                 self.decoder(
-                    input=vq_feats.transpose_(1, 2),
+                    x=vq_feats,
                 ).transpose_(1, 2),
             )
 


### PR DESCRIPTION
## Content:
This PR addresses the issue of redundant transposition operations:

1. The original DVAE forward method included a transpose operation:

 ```python
   dec_out = self.out_conv(
       self.decoder(
           input=vq_feats.transpose_(1, 2), <- here
       ).transpose_(1, 2),   <- and here
   )
```

2. This transpose was then repeated in the DVAEDecoder forward method:

```python
def forward(self, input: torch.Tensor, conditioning=None) -> torch.Tensor:
    # B, T, C
    x = input.transpose_(1, 2) <- again
    ...
    return x.transpose_(1, 2) <-  also extraneous transpose
```