### PR TITLE
feat(api): add chattts api example using fastapi

### DIFF
--- a/examples/api/README.md
+++ b/examples/api/README.md
@@ -1,0 +1,23 @@
+# Generating voice with ChatTTS via API
+
+## Install requirements
+
+Install `FastAPI` and `requests`:
+
+```
+pip install -r examples/api/requirements.txt
+```
+
+## Run API server
+
+```
+fastapi dev examples/api/main.py --host 0.0.0.0 --port 8000
+```
+
+## Generate audio using requests
+
+```
+python examples/api/client.py
+```
+
+mp3 audio files will be saved to the `output` directory.

--- a/examples/api/client.py
+++ b/examples/api/client.py
@@ -1,0 +1,75 @@
+import datetime
+import os
+import requests
+import zipfile
+
+chattts_service_host = os.environ.get("CHATTTS_SERVICE_HOST", "localhost")
+chattts_service_port = os.environ.get("CHATTTS_SERVICE_PORT", "8000")
+
+CHATTTS_URL = f"http://{chattts_service_host}:{chattts_service_port}/generate_voice"
+
+
+# main infer params
+body = {
+    "text": [
+        "四川美食确实以辣闻名，但也有不辣的选择。",
+        "比如甜水面、赖汤圆、蛋烘糕、叶儿粑等，这些小吃口味温和，甜而不腻，也很受欢迎。",
+    ],
+    "stream": False,
+    "lang": None,
+    "skip_refine_text": True,
+    "refine_text_only": False,
+    "use_decoder": True,
+    "audio_seed": 12345678,
+    "text_seed": 87654321,
+    "do_text_normalization": True,
+    "do_homophone_replacement": False,
+}
+
+# refine text params
+params_refine_text = {
+    "prompt": "",
+    "top_P": 0.7,
+    "top_K": 20,
+    "temperature": 0.7,
+    "repetition_penalty": 1,
+    "max_new_token": 384,
+    "min_new_token": 0,
+    "show_tqdm": True,
+    "ensure_non_empty": True,
+    "stream_batch": 24,
+}
+body["params_refine_text"] = params_refine_text
+
+# infer code params
+params_infer_code = {
+    "prompt": "[speed_5]",
+    "top_P": 0.1,
+    "top_K": 20,
+    "temperature": 0.3,
+    "repetition_penalty": 1.05,
+    "max_new_token": 2048,
+    "min_new_token": 0,
+    "show_tqdm": True,
+    "ensure_non_empty": True,
+    "stream_batch": True,
+    "spk_emb": None,
+}
+body["params_infer_code"] = params_infer_code
+
+
+try:
+    response = requests.post(CHATTTS_URL, json=body)
+    response.raise_for_status()
+    chattts_zipfile = f"chattts_audio_files.zip"
+    with open(chattts_zipfile, "wb") as f:
+        f.write(response.content)
+    with zipfile.ZipFile(chattts_zipfile, "r") as zip_ref:
+        # save files for each request in a different folder
+        dt = datetime.datetime.now()
+        ts = int(dt.timestamp())
+        zip_ref.extractall(f"./output/{ts}/")
+    os.remove(chattts_zipfile)
+
+except requests.exceptions.RequestException as e:
+    print(f"Error: {e}")

--- a/examples/api/main.py
+++ b/examples/api/main.py
@@ -1,0 +1,123 @@
+import io
+import os
+import sys
+import zipfile
+
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+
+
+if sys.platform == "darwin":
+    os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
+
+now_dir = os.getcwd()
+sys.path.append(now_dir)
+
+from typing import Any, Optional
+
+import ChatTTS
+
+from tools.audio import wav_arr_to_mp3_view
+from tools.logger import get_logger
+import torch
+
+
+from pydantic import BaseModel
+
+
+logger = get_logger("Command")
+
+
+def save_mp3_file(wav, index):
+    data = wav_arr_to_mp3_view(wav)
+    mp3_filename = f"output_audio_{index}.mp3"
+    with open(mp3_filename, "wb") as f:
+        f.write(data)
+    logger.info(f"Audio saved to {mp3_filename}")
+
+
+app = FastAPI()
+
+
+@app.on_event("startup")
+async def startup_event():
+    global chat
+
+    chat = ChatTTS.Chat(get_logger("ChatTTS"))
+    logger.info("Initializing ChatTTS...")
+    if chat.load():
+        logger.info("Models loaded successfully.")
+    else:
+        logger.error("Models load failed.")
+        sys.exit(1)
+
+
+class ChatTTSParams(BaseModel):
+    text: list[str]
+    stream: bool = False
+    lang: Any = None
+    skip_refine_text: bool = False
+    refine_text_only: bool = False
+    use_decoder: bool = True
+    do_text_normalization: bool = True
+    do_homophone_replacement: bool = False
+    audio_seed: int
+    text_seed: int
+    params_refine_text: ChatTTS.Chat.RefineTextParams
+    params_infer_code: ChatTTS.Chat.InferCodeParams
+
+
+@app.post("/generate_voice")
+async def generate_voice(params: ChatTTSParams):
+    logger.info("Text input: %s", str(params.text))
+
+    # audio seed
+    if params.audio_seed:
+        torch.manual_seed(params.audio_seed)
+        params.params_infer_code.spk_emb = chat.sample_random_speaker()
+
+    # text seed for text refining
+    if params.params_refine_text:
+        torch.manual_seed(params.text_seed)
+        text = chat.infer(
+            text=params.text, skip_refine_text=False, refine_text_only=True
+        )
+        logger.info(f"Refined text: {text}")
+    else:
+        # no text refining
+        text = params.text
+
+    logger.info("Use speaker:")
+    logger.info(params.params_infer_code.spk_emb)
+
+    logger.info("Start voice inference.")
+    wavs = chat.infer(
+        text=text,
+        stream=params.stream,
+        lang=params.lang,
+        skip_refine_text=params.skip_refine_text,
+        use_decoder=params.use_decoder,
+        do_text_normalization=params.do_text_normalization,
+        do_homophone_replacement=params.do_homophone_replacement,
+        params_infer_code=params.params_infer_code,
+        params_refine_text=params.params_refine_text,
+    )
+    logger.info("Inference completed.")
+
+    # Save each generated wav file to a local file
+    for index, wav in enumerate(wavs):
+        save_mp3_file(wav, index)
+    logger.info("Audio generation successful.")
+
+    # zip all of the audio files together
+    zip_buffer = io.BytesIO()
+    with zipfile.ZipFile(zip_buffer, "a", zipfile.ZIP_DEFLATED, False) as zip_file:
+        for idx in range(len(wavs)):
+            filepath = f"output_audio_{idx}.mp3"
+            zip_file.write(filepath, os.path.basename(filepath))
+
+    zip_buffer.seek(0)
+
+    response = StreamingResponse(zip_buffer, media_type="application/zip")
+    response.headers["Content-Disposition"] = "attachment; filename=audio_files.zip"
+    return response

--- a/examples/api/requirements.txt
+++ b/examples/api/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+requests


### PR DESCRIPTION
This PR adds an API example using FastAPI. Generated audio files are saved to a zip file which is returned in the response. I was using the `/generate_audio` endpoint included with the Gradio app in a previous version of ChatTTS, but that doesn't seem to be supported any more, so this provides an example for how to use ChatTTS via API without using gradio. I have also included a `client.py` example which shows how to use the API.

Related issues: 
close #491
close #448