### PR TITLE
cmd/jupyter流式代码简化优化；cmd/jupyter stream play example simplify

### DIFF
--- a/examples/cmd/stream.py
+++ b/examples/cmd/stream.py
@@ -1,4 +1,3 @@
-
 import time
 import random
 
@@ -6,130 +5,152 @@ import numpy as np
 
 from tools.audio import float_to_int16
 
+
 # 流式推理数据获取器，支持流式获取音频编码字节流
 class ChatStreamer:
-    def __init__(self,base_block_size=8000):
-        self.base_block_size=base_block_size
+    def __init__(self, base_block_size=8000):
+        self.base_block_size = base_block_size
+
     # stream状态更新。数据量不足的stream，先存一段时间，直到拿到足够数据，监控小块数据情况
     @staticmethod
-    def _update_stream(history_stream_wav,new_stream_wav,thre):
+    def _update_stream(history_stream_wav, new_stream_wav, thre):
         if history_stream_wav is not None:
-            result_stream=np.concatenate([history_stream_wav,new_stream_wav],axis=1)
-            is_keep_next=result_stream.shape[0]*result_stream.shape[1]<thre
-            if random.random()>0.1:
-                print("update_stream",is_keep_next,[i.shape if i is not None else None for i in result_stream])
+            result_stream = np.concatenate([history_stream_wav, new_stream_wav], axis=1)
+            is_keep_next = result_stream.shape[0] * result_stream.shape[1] < thre
+            if random.random() > 0.1:
+                print(
+                    "update_stream",
+                    is_keep_next,
+                    [i.shape if i is not None else None for i in result_stream],
+                )
         else:
-            result_stream=new_stream_wav
-            is_keep_next=result_stream.shape[0]*result_stream.shape[1]<thre
+            result_stream = new_stream_wav
+            is_keep_next = result_stream.shape[0] * result_stream.shape[1] < thre
 
-        return result_stream,is_keep_next
-    
+        return result_stream, is_keep_next
+
     # 已推理batch数据保存
     @staticmethod
-    def _accum(accum_wavs,stream_wav):
+    def _accum(accum_wavs, stream_wav):
         if accum_wavs is None:
-            accum_wavs=stream_wav
+            accum_wavs = stream_wav
         else:
-            accum_wavs=np.concatenate([accum_wavs,stream_wav],axis=1)
+            accum_wavs = np.concatenate([accum_wavs, stream_wav], axis=1)
         return accum_wavs
-    
+
     # batch stream数据格式转化
     @staticmethod
-    def batch_stream_formatted(stream_wav,output_format='PCM16_byte'):
-        if output_format in ('PCM16_byte','PCM16'):
+    def batch_stream_formatted(stream_wav, output_format="PCM16_byte"):
+        if output_format in ("PCM16_byte", "PCM16"):
             # format_data=ChatStreamer._batch_unsafe_float_to_int16(stream_wav)
-            format_data=float_to_int16(stream_wav)
+            format_data = float_to_int16(stream_wav)
         else:
-            format_data=stream_wav
+            format_data = stream_wav
         return format_data
-    
+
     # 数据格式转化
     @staticmethod
-    def formatted(data,output_format='PCM16_byte'):
-        if output_format=='PCM16_byte':
-            format_data=data.astype("<i2").tobytes()
+    def formatted(data, output_format="PCM16_byte"):
+        if output_format == "PCM16_byte":
+            format_data = data.astype("<i2").tobytes()
         else:
-            format_data=data
+            format_data = data
         return format_data
-    
+
     # 检查声音是否为空
     @staticmethod
     def checkvoice(data):
-        if np.abs(data).max()<1e-6:
+        if np.abs(data).max() < 1e-6:
             return False
         else:
             return True
-        
+
     # 将声音进行适当拆分返回
     @staticmethod
-    def _subgen(data,thre=12000):
-        for stard_idx in range(0,data.shape[0],thre):
-            end_idx=stard_idx+thre
+    def _subgen(data, thre=12000):
+        for stard_idx in range(0, data.shape[0], thre):
+            end_idx = stard_idx + thre
             yield data[stard_idx:end_idx]
-            
+
     # 流式数据获取，支持获取音频编码字节流
-    def generate(self,streamchat,output_format=None):
-        assert output_format in ('PCM16_byte','PCM16',None)
-        curr_sentence_index=0
-        history_stream_wav=None
-        article_streamwavs=None
+    def generate(self, streamchat, output_format=None):
+        assert output_format in ("PCM16_byte", "PCM16", None)
+        curr_sentence_index = 0
+        history_stream_wav = None
+        article_streamwavs = None
         for stream_wav in streamchat:
             print(np.abs(stream_wav).max(axis=1))
-            n_texts=len(stream_wav)
-            n_valid_texts=(np.abs(stream_wav).max(axis=1)>1e-6).sum()
-            if n_valid_texts==0:
+            n_texts = len(stream_wav)
+            n_valid_texts = (np.abs(stream_wav).max(axis=1) > 1e-6).sum()
+            if n_valid_texts == 0:
                 continue
             else:
-                block_thre=n_valid_texts*self.base_block_size
-                stream_wav,is_keep_next=ChatStreamer._update_stream(history_stream_wav,stream_wav,block_thre)
+                block_thre = n_valid_texts * self.base_block_size
+                stream_wav, is_keep_next = ChatStreamer._update_stream(
+                    history_stream_wav, stream_wav, block_thre
+                )
                 # 数据量不足，先保存状态
                 if is_keep_next:
-                    history_stream_wav=stream_wav
+                    history_stream_wav = stream_wav
                     continue
                 # 数据量足够，执行写入操作
                 else:
-                    history_stream_wav=None
-                    stream_wav=ChatStreamer.batch_stream_formatted(stream_wav,output_format)
-                    article_streamwavs=ChatStreamer._accum(article_streamwavs,stream_wav)
+                    history_stream_wav = None
+                    stream_wav = ChatStreamer.batch_stream_formatted(
+                        stream_wav, output_format
+                    )
+                    article_streamwavs = ChatStreamer._accum(
+                        article_streamwavs, stream_wav
+                    )
                     # 写入当前句子
-                    if  ChatStreamer.checkvoice(stream_wav[curr_sentence_index]):
-                        for sub_wav in ChatStreamer._subgen(stream_wav[curr_sentence_index]):
+                    if ChatStreamer.checkvoice(stream_wav[curr_sentence_index]):
+                        for sub_wav in ChatStreamer._subgen(
+                            stream_wav[curr_sentence_index]
+                        ):
                             if ChatStreamer.checkvoice(sub_wav):
-                                yield ChatStreamer.formatted(sub_wav,output_format)
+                                yield ChatStreamer.formatted(sub_wav, output_format)
                     # 当前句子已写入完成，直接写下一个句子已经推理完成的部分
-                    elif curr_sentence_index<n_texts-1:
-                        curr_sentence_index+=1
-                        print('add next sentence')
-                        finish_stream_wavs=article_streamwavs[curr_sentence_index]
-                        
+                    elif curr_sentence_index < n_texts - 1:
+                        curr_sentence_index += 1
+                        print("add next sentence")
+                        finish_stream_wavs = article_streamwavs[curr_sentence_index]
+
                         for sub_wav in ChatStreamer._subgen(finish_stream_wavs):
                             if ChatStreamer.checkvoice(sub_wav):
-                                yield ChatStreamer.formatted(sub_wav,output_format)
-                        
+                                yield ChatStreamer.formatted(sub_wav, output_format)
+
                     # streamchat遍历完毕，在外层把剩余结果写入
                     else:
                         break
         # 本轮剩余最后一点数据写入
         if is_keep_next:
-            if len(list(filter(lambda x:x is not None,stream_wav)))>0:
-                stream_wav=ChatStreamer.batch_stream_formatted(stream_wav,output_format)
-                if  ChatStreamer.checkvoice(stream_wav[curr_sentence_index]):
-                    
-                    for sub_wav in ChatStreamer._subgen(stream_wav[curr_sentence_index]):
+            if len(list(filter(lambda x: x is not None, stream_wav))) > 0:
+                stream_wav = ChatStreamer.batch_stream_formatted(
+                    stream_wav, output_format
+                )
+                if ChatStreamer.checkvoice(stream_wav[curr_sentence_index]):
+
+                    for sub_wav in ChatStreamer._subgen(
+                        stream_wav[curr_sentence_index]
+                    ):
                         if ChatStreamer.checkvoice(sub_wav):
-                            yield ChatStreamer.formatted(sub_wav,output_format)
-                    article_streamwavs=ChatStreamer._accum(article_streamwavs,stream_wav)
+                            yield ChatStreamer.formatted(sub_wav, output_format)
+                    article_streamwavs = ChatStreamer._accum(
+                        article_streamwavs, stream_wav
+                    )
         # 把已经完成推理的下几轮剩余数据写入
-        for i_text in range(curr_sentence_index+1,n_texts):
-            finish_stream_wavs=article_streamwavs[i_text]
-            
+        for i_text in range(curr_sentence_index + 1, n_texts):
+            finish_stream_wavs = article_streamwavs[i_text]
+
             for sub_wav in ChatStreamer._subgen(finish_stream_wavs):
                 if ChatStreamer.checkvoice(sub_wav):
-                    yield ChatStreamer.formatted(sub_wav,output_format)
+                    yield ChatStreamer.formatted(sub_wav, output_format)
+
     # 流式播放接口
-    def play(self,streamchat,wait=5):
+    def play(self, streamchat, wait=5):
         import pyaudio  # please install it manually
         import time
+
         p = pyaudio.PyAudio()
         print(p.get_device_count())
         # 设置音频流参数
@@ -139,24 +160,30 @@ class ChatStreamer:
         CHUNK = 1024  # 每块音频数据大小
 
         # 打开输出流（扬声器）
-        stream_out = p.open(format=FORMAT, channels=CHANNELS, rate=RATE, output=True,)
+        stream_out = p.open(
+            format=FORMAT,
+            channels=CHANNELS,
+            rate=RATE,
+            output=True,
+        )
 
-        first_prefill_size=wait*RATE
-        prefill_bytes=b''
-        meet=False
-        for i in self.generate(streamchat,output_format='PCM16_byte'):
+        first_prefill_size = wait * RATE
+        prefill_bytes = b""
+        meet = False
+        for i in self.generate(streamchat, output_format="PCM16_byte"):
             if not meet:
-                prefill_bytes+=i
-                if len(prefill_bytes)>first_prefill_size:
-                    meet=True
-                    stream_out.write(prefill_bytes)    
+                prefill_bytes += i
+                if len(prefill_bytes) > first_prefill_size:
+                    meet = True
+                    stream_out.write(prefill_bytes)
             else:
-                stream_out.write(i)    
+                stream_out.write(i)
         if not meet:
-            stream_out.write(prefill_bytes)    
+            stream_out.write(prefill_bytes)
 
         stream_out.stop_stream()
         stream_out.close()
+
 
 if __name__ == "__main__":
     import ChatTTS
@@ -182,7 +209,7 @@ if __name__ == "__main__":
         ],
         skip_refine_text=True,
         stream=True,
-        params_infer_code=params_infer_code
+        params_infer_code=params_infer_code,
     )
     # 先存放一部分，存的差不多了再播放，适合生成速度比较慢的cpu玩家使用
-    ChatStreamer().play(streamchat,wait=5)
+    ChatStreamer().play(streamchat, wait=5)

--- a/examples/cmd/stream.py
+++ b/examples/cmd/stream.py
@@ -1,220 +1,129 @@
-import io
-import threading
+
 import time
 import random
 
-import pyaudio  # please install it manually
 import numpy as np
-import ChatTTS
 
-from tools.audio import batch_unsafe_float_to_int16
+from tools.audio import unsafe_float_to_int16
 
+class BatchStreamer:
+    @classmethod
+    def _batch_unsafe_float_to_int16(cls,audios):
+        valid_audios_info=[(index,audio.shape[0]) for index,audio in enumerate(audios) if audio is not None]
+        allmax_size=max([i[1] for i in valid_audios_info])
+        valid_audios=np.zeros((len(valid_audios_info),allmax_size))
+        for valid_index,(index,maxsize) in enumerate(valid_audios_info):
+            valid_audios[valid_index,:maxsize]=audios[index]
+        
+        valid_audios=unsafe_float_to_int16(valid_audios)
+        result_audios=[None]*len(audios)
+        for i,(valid_index,max_size) in enumerate(valid_audios_info):
+            result_audios[valid_index]=valid_audios[i,:max_size]
+        return result_audios
+        
+    # stream状态更新。数据量不足的stream，先存一段时间，直到拿到足够数据，监控小块数据情况
+    @classmethod
+    def _update_stream(cls,history_stream_wav,new_stream_wav,thre):
+        result_stream=[]
+        if history_stream_wav is not None:
+            n_texts=len(new_stream_wav)
+            for i in range(n_texts):
+                if new_stream_wav[i] is not None:
+                    result_stream.append(np.concatenate([history_stream_wav[i],new_stream_wav[i]]))
+                else:
+                    result_stream.append(history_stream_wav[i])
+            is_keep_next=sum([i.shape[0] for i in result_stream if i is not None])<thre
+            if random.random()>0.1:
+                print("update_stream",is_keep_next,[i.shape if i is not None else None for i in result_stream])
+        else:
+            result_stream=new_stream_wav
+            is_keep_next=sum([i.shape[0] for i in result_stream if i is not None])<thre
 
-# 流式声音处理器
-class AudioStreamer:
-    def __init__(self):
-        self.bio = io.BytesIO()
-        self.lock = threading.Lock()
-        self.seek_index = 0
-
-    # 流式写入
-    def write(self, waveform):
-        with self.lock:
-            #             waveform=(new_wave*32767).astype(np.int16)
-            #             waveform=unsafe_float_to_int16(new_wave)
-            # 将整数列表转换为字节字符串
-            write_binary = waveform.astype("<i2").tobytes()
-            self.bio.write(write_binary)
-
-    # 流式读取
-    def read(self):
-        with self.lock:
-            self.bio.seek(self.seek_index)
-            read_binary = self.bio.read()
-            self.seek_index += len(read_binary)
-        return read_binary
-
-
-# ChatTTS流式处理
-class ChatStreamer:
-    def __init__(self, waittime_topause=50, base_block_size=8000):
-        self.streamer = AudioStreamer()
-        self.accum_streamwavs = []
-        self.waittime_topause = waittime_topause
-        self.base_block_size = base_block_size
-
-    def write(self, chatstream):
-        # 已推理batch数据保存
-        def accum(accum_wavs, stream_wav):
-            n_texts = len(stream_wav)
-            if accum_wavs is None:
-                accum_wavs = [[i] for i in stream_wav]
-            else:
-                for i_text in range(n_texts):
-                    if stream_wav[i_text] is not None:
-                        accum_wavs[i_text].append(stream_wav[i_text])
-            return accum_wavs
-
-        # stream状态更新。数据量不足的stream，先存一段时间，直到拿到足够数据，监控小块数据情况
-        def update_stream(history_stream_wav, new_stream_wav, thre):
-            result_stream = []
-            randn = -1
-            if history_stream_wav is not None:
-                randn = random.random()
-                if randn > 0.1:
-                    print("update_stream")
-                n_texts = len(new_stream_wav)
-                for i in range(n_texts):
-                    if new_stream_wav[i] is not None:
-                        result_stream.append(
-                            np.concatenate(
-                                [history_stream_wav[i], new_stream_wav[i]], axis=1
-                            )
-                        )
-                    else:
-                        result_stream.append(history_stream_wav[i])
-            else:
-                result_stream = new_stream_wav
-
-            is_keep_next = (
-                sum([i.shape[1] for i in result_stream if i is not None]) < thre
-            )
-            if randn > 0.1:
-                print(
-                    "result_stream:",
-                    is_keep_next,
-                    [i.shape if i is not None else None for i in result_stream],
-                )
-            return result_stream, is_keep_next
-
-        self.finish = False
-        curr_sentence_index = 0
-        base_block_size = self.base_block_size
-        history_stream_wav = None
-        article_streamwavs = None
+        return result_stream,is_keep_next
+    
+    # 已推理batch数据保存
+    @classmethod
+    def _accum(cls,accum_wavs,stream_wav):
+        n_texts=len(stream_wav)
+        if accum_wavs is None:
+            accum_wavs=[[i] for i in stream_wav]
+        else:
+            for i_text in range(n_texts):
+                if stream_wav[i_text] is not None:
+                    accum_wavs[i_text].append(stream_wav[i_text])
+        return accum_wavs
+    
+    # batch stream数据格式转化
+    @classmethod
+    def batch_stream_formatted(cls,stream_wav,output_format='PCM16_byte'):
+        if output_format in ('PCM16_byte','PCM16'):
+            format_data=cls._batch_unsafe_float_to_int16(stream_wav)
+        else:
+            format_data=stream_wav
+        return format_data
+    
+    # 数据格式转化
+    @classmethod
+    def formatted(cls,data,output_format='PCM16_byte'):
+        if output_format=='PCM16_byte':
+            format_data=data.astype("<i2").tobytes()
+        else:
+            format_data=data
+        return format_data
+    
+    # 数据生成
+    @classmethod
+    def generate(cls,chatstream,output_format=None,base_block_size=8000):
+        assert output_format in ('PCM16_byte','PCM16',None)
+        curr_sentence_index=0
+        history_stream_wav=None
+        article_streamwavs=None
         for stream_wav in chatstream:
-            n_texts = len(stream_wav)
-            n_valid_texts = len(list(filter(lambda x: x is not None, stream_wav)))
-            if n_valid_texts == 0:
+            n_texts=len(stream_wav)
+            n_valid_texts=len(list(filter(lambda x:x is not None,stream_wav)))
+            if n_valid_texts==0:
                 continue
             else:
-                block_thre = n_valid_texts * base_block_size
-                stream_wav, is_keep_next = update_stream(
-                    history_stream_wav, stream_wav, block_thre
-                )
+                block_thre=n_valid_texts*base_block_size
+                stream_wav,is_keep_next=cls._update_stream(history_stream_wav,stream_wav,block_thre)
                 # 数据量不足，先保存状态
                 if is_keep_next:
-                    history_stream_wav = stream_wav
+                    history_stream_wav=stream_wav
                     continue
                 # 数据量足够，执行写入操作
                 else:
-                    history_stream_wav = None
-                    stream_wav = batch_unsafe_float_to_int16(stream_wav)
-                    article_streamwavs = accum(article_streamwavs, stream_wav)
+                    history_stream_wav=None
+                    stream_wav=cls.batch_stream_formatted(stream_wav,output_format)
+                    article_streamwavs=cls._accum(article_streamwavs,stream_wav)
                     # 写入当前句子
                     if stream_wav[curr_sentence_index] is not None:
-                        self.streamer.write(stream_wav[curr_sentence_index][0])
+                        yield cls.formatted(stream_wav[curr_sentence_index],output_format)
                     # 当前句子已写入完成，直接写下一个句子已经推理完成的部分
-                    elif curr_sentence_index < n_texts - 1:
-                        curr_sentence_index += 1
-                        print("add next sentence")
-                        finish_stream_wavs = np.concatenate(
-                            article_streamwavs[curr_sentence_index], axis=1
-                        )
-                        self.streamer.write(finish_stream_wavs[0])
+                    elif curr_sentence_index<n_texts-1:
+                        curr_sentence_index+=1
+                        print('add next sentence')
+                        finish_stream_wavs=np.concatenate(article_streamwavs[curr_sentence_index])
+                        yield cls.formatted(finish_stream_wavs,output_format)
                     # streamchat遍历完毕，在外层把剩余结果写入
                     else:
                         break
-            # 有一定概率遇到奇怪bug（一定概率遇到256维异常输出，正常是1w+维），输出全是噪声，写的快遇到的概率更高？
-            time.sleep(0.02)
         # 本轮剩余最后一点数据写入
         if is_keep_next:
-            if len(list(filter(lambda x: x is not None, stream_wav))) > 0:
-                stream_wav = batch_unsafe_float_to_int16(stream_wav)
+            if len(list(filter(lambda x:x is not None,stream_wav)))>0:
+                stream_wav=cls.batch_stream_formatted(stream_wav,output_format)
                 if stream_wav[curr_sentence_index] is not None:
-                    self.streamer.write(stream_wav[curr_sentence_index][0])
-                    article_streamwavs = accum(article_streamwavs, stream_wav)
+                    yield cls.formatted(stream_wav[curr_sentence_index],output_format)
+                    article_streamwavs=cls._accum(article_streamwavs,stream_wav)
         # 把已经完成推理的下几轮剩余数据写入
-        for i_text in range(curr_sentence_index + 1, n_texts):
-            finish_stream_wavs = np.concatenate(article_streamwavs[i_text], axis=1)
-            self.streamer.write(finish_stream_wavs[0])
+        for i_text in range(curr_sentence_index+1,n_texts):
+            finish_stream_wavs=np.concatenate(article_streamwavs[i_text])
+            yield cls.formatted(finish_stream_wavs,output_format)
 
-        self.accum_streamwavs.append(article_streamwavs)
-        self.finish = True
-
-    def play(self, waittime_tostart=5, auto_end=False):
-        # 初始化PyAudio对象
-        p = pyaudio.PyAudio()
-
-        # 设置音频流参数
-        FORMAT = pyaudio.paInt16  # 16位深度
-        CHANNELS = 1  # 单声道
-        RATE = 24000  # 采样率
-        CHUNK = 1024  # 每块音频数据大小
-
-        # 打开输出流（扬声器）
-        stream_out = p.open(format=FORMAT, channels=CHANNELS, rate=RATE, output=True)
-
-        print("开始流式音频播放...")
-        import time
-
-        time.sleep(waittime_tostart)
-
-        wait_time = 0
-        while (self.streamer.bio.tell() > self.streamer.seek_index) | (
-            wait_time < self.waittime_topause
-        ):
-
-            if self.streamer.bio.tell() > self.streamer.seek_index:
-                read_data = self.streamer.read()
-                stream_out.write(read_data)
-                wait_time = 0
-            # 如果不设置自动结束，就等待一段时间，如果一直没有新写入，就自动结束。如果设置了自动结束，就在写操作结束时结束播放
-            else:
-                if auto_end & self.finish:
-                    print("写操作完成，自动结束。")
-                    break
-                else:
-                    time.sleep(self.waittime_topause / 10)
-                    wait_time += self.waittime_topause / 10
-
-        print("完成流式音频播放...")
-        stream_out.stop_stream()
-        stream_out.close()
-
-    # 获取完整历史播放数据
-    def get_complete_speech(self):
-        complete_waveform = np.concatenate(
-            sum([sum(i_infer, []) for i_infer in self.accum_streamwavs], []), axis=1
-        )
-        return complete_waveform
-
-    # 开始音频写入。可支持多次音频写入
-    def start_writing(self, streamchat):
-        self.writer = threading.Thread(target=self.write, args=(streamchat,))
-        self.writer.start()
-
-    # 开始音频播放
-    def start_playing(self, waittime_tostart=5):
-        self.player = threading.Thread(target=self.play, args=(waittime_tostart,))
-        self.player.start()
-
-    # writer和player完成join，需复杂操作可自行调用self.writer.join()或self.player.join()实现
-    def join(self):
-        self.writer.join()
-        self.player.join()
-
-    # 一次完整的音频写入+播放
-    def run(self, streamchat, waittime_tostart=5):
-        self.writer = threading.Thread(target=self.write, args=(streamchat,))
-        self.player = threading.Thread(target=self.play, args=(waittime_tostart, True))
-        self.writer.start()
-        self.player.start()
-        self.writer.join()
-        self.player.join()
 
 
 if __name__ == "__main__":
+    import ChatTTS
+    import pyaudio  # please install it manually
 
     # 加载 ChatTTS
     chat = ChatTTS.Chat()
@@ -228,57 +137,33 @@ if __name__ == "__main__":
         top_K=20,  # top K decode
     )
 
-    # 获取ChatTTS 流式推理generator
     streamchat = chat.infer(
         [
             "总结一下，AI Agent是大模型功能的扩展，让AI更接近于通用人工智能，也就是我们常说的AGI。",
-            "总结一下，AI Agent是大模型功能的扩展，让AI更接近于通用人工智能，也就是我们常说的AGI。它们共同协作，让AI不仅仅是理论上的智能，而是能够在现实世界中发挥作用的智能。",
             "你太聪明啦。",
             "举个例子，大模型可能可以写代码，但它不能独立完成一个完整的软件开发项目。这时候，AI Agent就根据大模型的智能，结合记忆和规划，使用合适的工具，一步步实现从需求分析到产品上线。",
-            "牛的牛的",
         ],
         skip_refine_text=True,
         params_infer_code=params_infer_code,
         stream=True,
     )
 
-    # 分别开启一个写线程和读线程，进行流式播放
-    streamer = ChatStreamer()
+    # 流式播放准备
+    p = pyaudio.PyAudio()
+    print(p.get_device_count())
+    # 设置音频流参数
+    FORMAT = pyaudio.paInt16  # 16位深度
+    CHANNELS = 1  # 单声道
+    RATE = 24000  # 采样率
+    CHUNK = 1024  # 每块音频数据大小
 
-    # 一次性生成
-    streamer.run(streamchat)
+    # 打开输出流（扬声器）
+    stream_out = p.open(format=FORMAT, channels=CHANNELS, rate=RATE, output=True,)
 
-    # 复杂使用示例：在同一个play中进行多次流式写入
-    streamchat1 = chat.infer(
-        [
-            "总结一下，AI Agent是大模型功能的扩展，让AI更接近于通用人工智能，也就是我们常说的AGI。",
-            "总结一下，AI Agent是大模型功能的扩展，让AI更接近于通用人工智能，也就是我们常说的AGI。它们共同协作，让AI不仅仅是理论上的智能，而是能够在现实世界中发挥作用的智能。",
-            "你太聪明啦。",
-            "举个例子，大模型可能可以写代码，但它不能独立完成一个完整的软件开发项目。这时候，AI Agent就根据大模型的智能，结合记忆和规划，使用合适的工具，一步步实现从需求分析到产品上线。",
-            "牛的牛的",
-        ],
-        skip_refine_text=True,
-        params_infer_code=params_infer_code,
-        stream=True,
-    )
+    # 流式推理，以音频编码字节流格式输出，并流式播放
+    for i in BatchStreamer.generate(streamchat,output_format='PCM16_byte'):
+        stream_out.write(i)    
+        
 
-    streamchat2 = chat.infer(
-        [
-            "四川美食确实以辣闻名，但也有不辣的选择。比如甜水面、赖汤圆、蛋烘糕、叶儿粑等，这些小吃口味温和，甜而不腻，也很受欢迎。",
-            "注意此版本可能不是最新版，所有内容请以英文版为准。",
-        ],
-        skip_refine_text=True,
-        params_infer_code=params_infer_code,
-        stream=True,
-    )
-
-    streamer.start_playing()
-
-    streamer.start_writing(streamchat1)
-    streamer.writer.join()
-    print("finish streamchat1")
-    streamer.start_writing(streamchat2)
-    streamer.writer.join()
-    print("finish streamchat2")
-    streamer.player.join()
-    print("finish play")
+    stream_out.stop_stream()
+    stream_out.close()

--- a/examples/cmd/stream.py
+++ b/examples/cmd/stream.py
@@ -4,89 +4,84 @@ import random
 
 import numpy as np
 
-from tools.audio import unsafe_float_to_int16
+from tools.audio import float_to_int16
 
 # 流式推理数据获取器，支持流式获取音频编码字节流
-class BatchStreamer:
-    @classmethod
-    def _batch_unsafe_float_to_int16(cls,audios):
-        valid_audios_info=[(index,audio.shape[0]) for index,audio in enumerate(audios) if audio is not None]
-        allmax_size=max([i[1] for i in valid_audios_info])
-        valid_audios=np.zeros((len(valid_audios_info),allmax_size))
-        for valid_index,(index,maxsize) in enumerate(valid_audios_info):
-            valid_audios[valid_index,:maxsize]=audios[index]
-        
-        valid_audios=unsafe_float_to_int16(valid_audios)
-        result_audios=[None]*len(audios)
-        for i,(valid_index,max_size) in enumerate(valid_audios_info):
-            result_audios[valid_index]=valid_audios[i,:max_size]
-        return result_audios
-        
+class ChatStreamer:
+    def __init__(self,base_block_size=8000):
+        self.base_block_size=base_block_size
     # stream状态更新。数据量不足的stream，先存一段时间，直到拿到足够数据，监控小块数据情况
-    @classmethod
-    def _update_stream(cls,history_stream_wav,new_stream_wav,thre):
-        result_stream=[]
+    @staticmethod
+    def _update_stream(history_stream_wav,new_stream_wav,thre):
         if history_stream_wav is not None:
-            n_texts=len(new_stream_wav)
-            for i in range(n_texts):
-                if new_stream_wav[i] is not None:
-                    result_stream.append(np.concatenate([history_stream_wav[i],new_stream_wav[i]]))
-                else:
-                    result_stream.append(history_stream_wav[i])
-            is_keep_next=sum([i.shape[0] for i in result_stream if i is not None])<thre
+            result_stream=np.concatenate([history_stream_wav,new_stream_wav],axis=1)
+            is_keep_next=result_stream.shape[0]*result_stream.shape[1]<thre
             if random.random()>0.1:
                 print("update_stream",is_keep_next,[i.shape if i is not None else None for i in result_stream])
         else:
             result_stream=new_stream_wav
-            is_keep_next=sum([i.shape[0] for i in result_stream if i is not None])<thre
+            is_keep_next=result_stream.shape[0]*result_stream.shape[1]<thre
 
         return result_stream,is_keep_next
     
     # 已推理batch数据保存
-    @classmethod
-    def _accum(cls,accum_wavs,stream_wav):
-        n_texts=len(stream_wav)
+    @staticmethod
+    def _accum(accum_wavs,stream_wav):
         if accum_wavs is None:
-            accum_wavs=[[i] for i in stream_wav]
+            accum_wavs=stream_wav
         else:
-            for i_text in range(n_texts):
-                if stream_wav[i_text] is not None:
-                    accum_wavs[i_text].append(stream_wav[i_text])
+            accum_wavs=np.concatenate([accum_wavs,stream_wav],axis=1)
         return accum_wavs
     
     # batch stream数据格式转化
-    @classmethod
-    def batch_stream_formatted(cls,stream_wav,output_format='PCM16_byte'):
+    @staticmethod
+    def batch_stream_formatted(stream_wav,output_format='PCM16_byte'):
         if output_format in ('PCM16_byte','PCM16'):
-            format_data=cls._batch_unsafe_float_to_int16(stream_wav)
+            # format_data=ChatStreamer._batch_unsafe_float_to_int16(stream_wav)
+            format_data=float_to_int16(stream_wav)
         else:
             format_data=stream_wav
         return format_data
     
     # 数据格式转化
-    @classmethod
-    def formatted(cls,data,output_format='PCM16_byte'):
+    @staticmethod
+    def formatted(data,output_format='PCM16_byte'):
         if output_format=='PCM16_byte':
             format_data=data.astype("<i2").tobytes()
         else:
             format_data=data
         return format_data
     
-    # 数据生成
-    @classmethod
-    def generate(cls,chatstream,output_format=None,base_block_size=8000):
+    # 检查声音是否为空
+    @staticmethod
+    def checkvoice(data):
+        if np.abs(data).max()<1e-6:
+            return False
+        else:
+            return True
+        
+    # 将声音进行适当拆分返回
+    @staticmethod
+    def _subgen(data,thre=12000):
+        for stard_idx in range(0,data.shape[0],thre):
+            end_idx=stard_idx+thre
+            yield data[stard_idx:end_idx]
+            
+    # 流式数据获取，支持获取音频编码字节流
+    def generate(self,streamchat,output_format=None):
         assert output_format in ('PCM16_byte','PCM16',None)
         curr_sentence_index=0
         history_stream_wav=None
         article_streamwavs=None
-        for stream_wav in chatstream:
+        for stream_wav in streamchat:
+            print(np.abs(stream_wav).max(axis=1))
             n_texts=len(stream_wav)
-            n_valid_texts=len(list(filter(lambda x:x is not None,stream_wav)))
+            n_valid_texts=(np.abs(stream_wav).max(axis=1)>1e-6).sum()
             if n_valid_texts==0:
                 continue
             else:
-                block_thre=n_valid_texts*base_block_size
-                stream_wav,is_keep_next=cls._update_stream(history_stream_wav,stream_wav,block_thre)
+                block_thre=n_valid_texts*self.base_block_size
+                stream_wav,is_keep_next=ChatStreamer._update_stream(history_stream_wav,stream_wav,block_thre)
                 # 数据量不足，先保存状态
                 if is_keep_next:
                     history_stream_wav=stream_wav
@@ -94,89 +89,77 @@ class BatchStreamer:
                 # 数据量足够，执行写入操作
                 else:
                     history_stream_wav=None
-                    stream_wav=cls.batch_stream_formatted(stream_wav,output_format)
-                    article_streamwavs=cls._accum(article_streamwavs,stream_wav)
+                    stream_wav=ChatStreamer.batch_stream_formatted(stream_wav,output_format)
+                    article_streamwavs=ChatStreamer._accum(article_streamwavs,stream_wav)
                     # 写入当前句子
-                    if stream_wav[curr_sentence_index] is not None:
-                        yield cls.formatted(stream_wav[curr_sentence_index],output_format)
+                    if  ChatStreamer.checkvoice(stream_wav[curr_sentence_index]):
+                        for sub_wav in ChatStreamer._subgen(stream_wav[curr_sentence_index]):
+                            if ChatStreamer.checkvoice(sub_wav):
+                                yield ChatStreamer.formatted(sub_wav,output_format)
                     # 当前句子已写入完成，直接写下一个句子已经推理完成的部分
                     elif curr_sentence_index<n_texts-1:
                         curr_sentence_index+=1
                         print('add next sentence')
-                        finish_stream_wavs=np.concatenate(article_streamwavs[curr_sentence_index])
-                        yield cls.formatted(finish_stream_wavs,output_format)
+                        finish_stream_wavs=article_streamwavs[curr_sentence_index]
+                        
+                        for sub_wav in ChatStreamer._subgen(finish_stream_wavs):
+                            if ChatStreamer.checkvoice(sub_wav):
+                                yield ChatStreamer.formatted(sub_wav,output_format)
+                        
                     # streamchat遍历完毕，在外层把剩余结果写入
                     else:
                         break
         # 本轮剩余最后一点数据写入
         if is_keep_next:
             if len(list(filter(lambda x:x is not None,stream_wav)))>0:
-                stream_wav=cls.batch_stream_formatted(stream_wav,output_format)
-                if stream_wav[curr_sentence_index] is not None:
-                    yield cls.formatted(stream_wav[curr_sentence_index],output_format)
-                    article_streamwavs=cls._accum(article_streamwavs,stream_wav)
+                stream_wav=ChatStreamer.batch_stream_formatted(stream_wav,output_format)
+                if  ChatStreamer.checkvoice(stream_wav[curr_sentence_index]):
+                    
+                    for sub_wav in ChatStreamer._subgen(stream_wav[curr_sentence_index]):
+                        if ChatStreamer.checkvoice(sub_wav):
+                            yield ChatStreamer.formatted(sub_wav,output_format)
+                    article_streamwavs=ChatStreamer._accum(article_streamwavs,stream_wav)
         # 把已经完成推理的下几轮剩余数据写入
         for i_text in range(curr_sentence_index+1,n_texts):
-            finish_stream_wavs=np.concatenate(article_streamwavs[i_text])
-            yield cls.formatted(finish_stream_wavs,output_format)
+            finish_stream_wavs=article_streamwavs[i_text]
+            
+            for sub_wav in ChatStreamer._subgen(finish_stream_wavs):
+                if ChatStreamer.checkvoice(sub_wav):
+                    yield ChatStreamer.formatted(sub_wav,output_format)
+    # 流式播放接口
+    def play(self,streamchat,wait=5):
+        import pyaudio  # please install it manually
+        import time
+        p = pyaudio.PyAudio()
+        print(p.get_device_count())
+        # 设置音频流参数
+        FORMAT = pyaudio.paInt16  # 16位深度
+        CHANNELS = 1  # 单声道
+        RATE = 24000  # 采样率
+        CHUNK = 1024  # 每块音频数据大小
 
+        # 打开输出流（扬声器）
+        stream_out = p.open(format=FORMAT, channels=CHANNELS, rate=RATE, output=True,)
 
-
-# 直接播放
-def example_0(streamchat):
-    import time
-    p = pyaudio.PyAudio()
-    print(p.get_device_count())
-    # 设置音频流参数
-    FORMAT = pyaudio.paInt16  # 16位深度
-    CHANNELS = 1  # 单声道
-    RATE = 24000  # 采样率
-    CHUNK = 1024  # 每块音频数据大小
-
-    # 打开输出流（扬声器）
-    stream_out = p.open(format=FORMAT, channels=CHANNELS, rate=RATE, output=True,)
-
-    for i in (BatchStreamer.generate(streamchat,output_format='PCM16_byte')):
-        stream_out.write(i)    
-
-    stream_out.stop_stream()
-    stream_out.close()
-
-# 先存放一部分，存的差不多了再播放，适合生成速度比较慢的cpu玩家使用
-def example_1(streamchat,first_prefill_size=300000):
-    import time
-    p = pyaudio.PyAudio()
-    print(p.get_device_count())
-    # 设置音频流参数
-    FORMAT = pyaudio.paInt16  # 16位深度
-    CHANNELS = 1  # 单声道
-    RATE = 24000  # 采样率
-    CHUNK = 1024  # 每块音频数据大小
-
-    # 打开输出流（扬声器）
-    stream_out = p.open(format=FORMAT, channels=CHANNELS, rate=RATE, output=True,)
-
-    prefill_bytes=b''
-    meet=False
-    for i in (BatchStreamer.generate(streamchat,output_format='PCM16_byte')):
+        first_prefill_size=wait*RATE
+        prefill_bytes=b''
+        meet=False
+        for i in self.generate(streamchat,output_format='PCM16_byte'):
+            if not meet:
+                prefill_bytes+=i
+                if len(prefill_bytes)>first_prefill_size:
+                    meet=True
+                    stream_out.write(prefill_bytes)    
+            else:
+                stream_out.write(i)    
         if not meet:
-            prefill_bytes+=i
-            if len(prefill_bytes)>first_prefill_size:
-                meet=True
-                stream_out.write(prefill_bytes)    
-        else:
-            stream_out.write(i)    
-    if not meet:
-        stream_out.write(prefill_bytes)    
+            stream_out.write(prefill_bytes)    
 
-
-    stream_out.stop_stream()
-    stream_out.close()
+        stream_out.stop_stream()
+        stream_out.close()
 
 if __name__ == "__main__":
     import ChatTTS
-    import pyaudio  # please install it manually
-
 
     # 加载 ChatTTS
     chat = ChatTTS.Chat()
@@ -195,20 +178,6 @@ if __name__ == "__main__":
         [
             "总结一下，AI Agent是大模型功能的扩展，让AI更接近于通用人工智能，也就是我们常说的AGI。",
             "你太聪明啦。",
-            "举个例子，大模型可能可以写代码，但它不能独立完成一个完整的软件开发项目。这时候，AI Agent就根据大模型的智能，结合记忆和规划，使用合适的工具，一步步实现从需求分析到产品上线。",
-        ],
-        skip_refine_text=True,
-        params_infer_code=params_infer_code,
-        stream=True,
-    )
-    # 直接播放
-    example_0(streamchat)
-
-    # 获取ChatTTS 流式推理generator
-    streamchat = chat.infer(
-        [
-            "总结一下，AI Agent是大模型功能的扩展，让AI更接近于通用人工智能，也就是我们常说的AGI。",
-            "你太聪明啦。",
             "举个例子，大模型可能可以写代码，但它不能独立完成一个完整的软件开发项目。这时候，AI Agent就根据大模型的智能，结合记忆和规划，一步步实现从需求分析到产品上线。",
         ],
         skip_refine_text=True,
@@ -216,4 +185,4 @@ if __name__ == "__main__":
         params_infer_code=params_infer_code
     )
     # 先存放一部分，存的差不多了再播放，适合生成速度比较慢的cpu玩家使用
-    example_1(streamchat,first_prefill_size=300000)
+    ChatStreamer().play(streamchat,wait=5)


### PR DESCRIPTION
简化cmd/jupyter模式下的流式代码样例，做了更合理的抽象，支持直接流式获取音频编码字节流，去除了难以修改调整的多线程，只保留了必要的文章内容流式获取类，现在可以比较简单的接入服务端-客户端音频开发需求，也能支持本地音频开发测试
Simplified cmd/jupyter mode under the stream code sample, do a more reasonable abstraction, remove the difficult to modify the adjustment of multi-threading, only retain the necessary article content stream access class, now can be relatively simple access to server-side - client audio development needs, Local audio development testing is also supported
#529