### PR TITLE
fix stream mode, last chunk of audio file size

### DIFF
--- a/ChatTTS/core.py
+++ b/ChatTTS/core.py
@@ -412,6 +412,7 @@ class Chat:
                 a = length[i]
                 b = len(wavs[i])
                 new_wavs[i, : b - a] = wavs[i, a:]
+                new_wavs[i, b - a :] = 0
             # Remove padding zeros
             keep_cols = np.sum(new_wavs != 0, axis=0) > 0
             new_wavs = np.delete(new_wavs, np.where(~keep_cols)[0], axis=1)

--- a/ChatTTS/core.py
+++ b/ChatTTS/core.py
@@ -414,8 +414,10 @@ class Chat:
                 new_wavs[i, : b - a] = wavs[i, a:]
                 new_wavs[i, b - a :] = 0
             # Remove padding zeros
+            keep_rows = np.any(new_wavs != 0, axis=1)
             keep_cols = np.sum(new_wavs != 0, axis=0) > 0
-            new_wavs = np.delete(new_wavs, np.where(~keep_cols)[0], axis=1)
+            # Filter both rows and columns using slicing
+            new_wavs = new_wavs[keep_rows, :][:, keep_cols]
             yield new_wavs
 
     @torch.inference_mode()

--- a/ChatTTS/core.py
+++ b/ChatTTS/core.py
@@ -410,8 +410,7 @@ class Chat:
             # keep_rows = np.any(array != 0, axis=1)
             keep_cols = np.sum(new_wavs != 0, axis=0) > 0
             # Filter both rows and columns using slicing
-            result = new_wavs[:][:, keep_cols]
-            yield result
+            yield new_wavs[:][:, keep_cols]
 
     @torch.inference_mode()
     def _vocos_decode(self, spec: torch.Tensor) -> np.ndarray:

--- a/ChatTTS/core.py
+++ b/ChatTTS/core.py
@@ -407,12 +407,15 @@ class Chat:
             else:
                 yield wavs
         if stream:
+            new_wavs = np.zeros((wavs.shape[0], params_infer_code.stream_speed))
             for i in range(wavs.shape[0]):
                 a = length[i]
                 b = len(wavs[i])
-                wavs[i, : b - a] = wavs[i, a:]
-                wavs[i, b - a :] = 0
-            yield wavs
+                new_wavs[i, : b - a] = wavs[i, a:]
+            # Remove padding zeros
+            keep_cols = np.sum(new_wavs != 0, axis=0) > 0
+            new_wavs = np.delete(new_wavs, np.where(~keep_cols)[0], axis=1)
+            yield new_wavs
 
     @torch.inference_mode()
     def _vocos_decode(self, spec: torch.Tensor) -> np.ndarray:


### PR DESCRIPTION
1. Request buffer size.
2. Remove padding zeros.

https://github.com/2noise/ChatTTS/issues/521

```
## stream mode
[idx=1] 总耗时: 18.45 递增耗时:0.00 Received: len(message)=16000 Total: 16000
[idx=2] 总耗时: 19.46 递增耗时:1.01 Received: len(message)=16000 Total: 32000
[idx=3] 总耗时: 20.33 递增耗时:0.87 Received: len(message)=16000 Total: 48000
[idx=4] 总耗时: 21.05 递增耗时:0.72 Received: len(message)=16000 Total: 64000
[idx=5] 总耗时: 21.05 递增耗时:0.00 Received: len(message)=14848 Total: 78848

## no-stream mode
[idx=1] 总耗时: 4.23 递增耗时:0.00 Received: len(message)=78848 Total: 78848
```