### PR TITLE
fix: topK and topP not valid

### DIFF
--- a/ChatTTS/core.py
+++ b/ChatTTS/core.py
@@ -595,7 +595,5 @@ class Chat:
         )
 
         del emb, input_ids
-        del_all(logits_warpers)
-        del_all(logits_processors)
 
         return result


### PR DESCRIPTION
The code is not valid 

```
del_all(logits_warpers)
del_all(logits_processors)
```

for `generate` function is used `yield` as a return. As a result , `generate` has not been finished yet, and the wrapper has beed deleted. 