### PR TITLE
fix: gpu change to cpu overhead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,4 @@ cython_debug/
 # inferred result
 *.wav
 *.mp3
+.idea

--- a/ChatTTS/model/velocity/model_runner.py
+++ b/ChatTTS/model/velocity/model_runner.py
@@ -567,9 +567,9 @@ class ModelRunner:
         # )
         results = []
         for i in range(idx_next.shape[0]):
-            idx_next_i = idx_next[i, 0, :].cpu().tolist()
-            logprob_i = logprob[i].cpu().tolist()
-            tmp_hidden_states = hidden_states[i].cpu()
+            idx_next_i = idx_next[i, 0, :].tolist()
+            logprob_i = logprob[i].tolist()
+            tmp_hidden_states = hidden_states[i]
             if input_tokens[i].shape[-2] != 1:
                 tmp_hidden_states = tmp_hidden_states[-1:, :]
             result = SequenceGroupOutput(


### PR DESCRIPTION
When I try 4090, it was slower than v100, and the speed is related to the number of cpus. Finally , I find out the overhead of it , for cpu and gpu repeat switch !