### PR TITLE
fix a bug of transformer-engine

### DIFF
--- a/ChatTTS/core.py
+++ b/ChatTTS/core.py
@@ -167,7 +167,13 @@ class Chat:
 
     @torch.no_grad()
     def _sample_random_speaker(self) -> torch.Tensor:
-        dim: int = self.gpt.gpt.layers[0].mlp.gate_proj.in_features
+        dim: int = (
+            self.gpt.gpt.layers[0].layernorm_mlp.fc1_weight.size(1)
+            # dim: int = self.gpt.gpt.layers[0].layernorm_mlp.hidden_size
+            # requires transformer-engine>=1.9
+            if self.gpt.is_te_llama
+            else self.gpt.gpt.layers[0].mlp.gate_proj.in_features
+        )
         spk = (
             torch.randn(dim, device=self.std.device, dtype=self.std.dtype)
             .mul_(self.std)


### PR DESCRIPTION
Fix #579 .

> Note: transformer-engine is still not feasible after this small fix currently because of device concerns.

```
Traceback (most recent call last):
  File "/home/user/workspace/ChatTTS/finetune.py", line 440, in <module>
    main()
  File "/home/user/workspace/ChatTTS/finetune.py", line 408, in main
    speaker_embeds = train(chat=chat, dataset=dataset, train_module=train_module, batch_size=batch_size, epochs=epochs, **kwargs)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/workspace/ChatTTS/finetune.py", line 277, in train_gpt
    outputs = chat.gpt.gpt.forward(inputs_embeds=inputs_embeds, attention_mask=attention_mask)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/miniconda3/envs/py312/lib/python3.12/site-packages/transformers/models/llama/modeling_llama.py", line 920, in forward
    position_embeddings = self.rotary_emb(hidden_states, position_ids)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/miniconda3/envs/py312/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1553, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/miniconda3/envs/py312/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1562, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/miniconda3/envs/py312/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/miniconda3/envs/py312/lib/python3.12/site-packages/transformers/models/llama/modeling_llama.py", line 153, in forward
    freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
             ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cpu and cuda:0! (when checking argument for argument mat2 in method wrapper_CUDA_bmm)
```