### PR TITLE
Add finetuning support for `Speaker` class

### DIFF
--- a/ChatTTS/model/speaker.py
+++ b/ChatTTS/model/speaker.py
@@ -16,22 +16,24 @@ class Speaker:
         self.dim = dim
 
     def sample_random(self) -> str:
-        return self._encode(self._sample_random())
+        return self._encode(self.sample_random_tensor())
 
     @torch.no_grad()
     def apply(
         self,
         emb: torch.Tensor,
-        spk_emb: str,
+        spk_emb: Union[str, torch.Tensor],
         input_ids: torch.Tensor,
         spk_emb_ids: int,
         device: torch.device,
     ):
+        if isinstance(spk_emb, str):
+            spk_emb_tensor = torch.from_numpy(self._decode(spk_emb))
+        else:
+            spk_emb_tensor = spk_emb
         n = (
             F.normalize(
-                torch.from_numpy(
-                    self._decode(spk_emb),
-                ),
+                spk_emb_tensor,
                 p=2.0,
                 dim=0,
                 eps=1e-12,
@@ -115,7 +117,7 @@ class Speaker:
         return torch.from_numpy(p.astype(np.int32)).view(*shp)
 
     @torch.no_grad()
-    def _sample_random(self) -> torch.Tensor:
+    def sample_random_tensor(self) -> torch.Tensor:
         spk = (
             torch.randn(self.dim, device=self.std.device, dtype=self.std.dtype)
             .mul_(self.std)

--- a/ChatTTS/model/speaker.py
+++ b/ChatTTS/model/speaker.py
@@ -16,7 +16,7 @@ class Speaker:
         self.dim = dim
 
     def sample_random(self) -> str:
-        return self._encode(self.sample_random_tensor())
+        return self._encode(self._sample_random())
 
     @torch.no_grad()
     def apply(
@@ -120,7 +120,7 @@ class Speaker:
         return torch.from_numpy(p.astype(np.int32)).view(*shp)
 
     @torch.no_grad()
-    def sample_random_tensor(self) -> torch.Tensor:
+    def _sample_random(self) -> torch.Tensor:
         spk = (
             torch.randn(self.dim, device=self.std.device, dtype=self.std.dtype)
             .mul_(self.std)

--- a/ChatTTS/model/speaker.py
+++ b/ChatTTS/model/speaker.py
@@ -27,7 +27,7 @@ class Speaker:
         spk_emb_ids: int,
         device: torch.device,
         inplace: bool = True,
-    ):
+    ) -> torch.Tensor:
         if isinstance(spk_emb, str):
             spk_emb_tensor = torch.from_numpy(self._decode(spk_emb))
         else:

--- a/ChatTTS/model/speaker.py
+++ b/ChatTTS/model/speaker.py
@@ -26,6 +26,7 @@ class Speaker:
         input_ids: torch.Tensor,
         spk_emb_ids: int,
         device: torch.device,
+        inplace: bool = True,
     ):
         if isinstance(spk_emb, str):
             spk_emb_tensor = torch.from_numpy(self._decode(spk_emb))
@@ -45,8 +46,10 @@ class Speaker:
             .expand(emb.shape)
         )
         cond = input_ids.narrow(-1, 0, 1).eq(spk_emb_ids).expand(emb.shape)
-        torch.where(cond, n, emb, out=emb)
-        del cond, n
+        out = torch.where(cond, n, emb, out=emb if inplace else None)
+        if inplace:
+            del cond, n
+        return out
 
     @staticmethod
     @torch.no_grad()


### PR DESCRIPTION
To allow tuning for `speaker_embeds` tensor. The PR includes:

1. Rename: `_sample_random -> sample_random_tensor` to allow usage out of class.
2. The `spk_emb` argument in `Speaker.apply()` changes `str -> Union[str, torch.Tensor]`
3. Add `inplace` argument to support gradient backward when setting to `False`
4. Update return type to return `torch.Tensor`

Besides, I don't quite see the advantage and motivation to encode the `speaker_embeds` tensor to string. To me, it only makes things more complex. I would personally prefer cpu `torch.Tensor` or `np.ndarray`

cc @fumiama 