### PR TITLE
fix invalid_characters bug

### DIFF
--- a/ChatTTS/norm.py
+++ b/ChatTTS/norm.py
@@ -97,6 +97,8 @@ class Normalizer:
         self.english_word_pattern = re.compile(r"\b[A-Za-z]+\b")
         self.character_simplifier = str.maketrans(
             {
+                "？": "。",
+                "?": ".",
                 "：": "，",
                 "；": "，",
                 "！": "。",
@@ -182,6 +184,7 @@ class Normalizer:
         if len(invalid_characters):
             self.logger.warning(f"found invalid characters: {invalid_characters}")
             text = self._apply_character_map(text)
+            invalid_characters = self._count_invalid_characters(text)
         if do_homophone_replacement:
             arr, replaced_words = _fast_replace(
                 self.homophones_map,


### PR DESCRIPTION
There are 2 issues.

1. In Chinese/English dataset texts, there are often "?" or "？". Currently, they are regarded as invalid characters but no map in `character_simplier`.
2. We should call `count_invalid_characters` again after `_apply_character_map`. Otherwise, if there is still no tag in text, It would go into the next if condition and raise an error because `tags` are None.

https://github.com/2noise/ChatTTS/blob/69aa9001e6bceb2b3c9f6db24b9b4a5e8b0a734e/ChatTTS/norm.py#L194-L200