### PR TITLE
Fix device mismatch error in embedding loading on branch dev

### DIFF
--- a/ChatTTS/core.py
+++ b/ChatTTS/core.py
@@ -272,6 +272,7 @@ class Chat:
                 vq_config=asdict(self.config.dvae.vq),
                 dim=self.config.dvae.decoder.idim,
                 coef=coef,
+                device=self.device,
             )
             .to(device)
             .eval()

--- a/ChatTTS/core.py
+++ b/ChatTTS/core.py
@@ -288,8 +288,8 @@ class Chat:
             self.config.embed.num_text_tokens,
             self.config.embed.num_vq,
         )
-        embed.from_pretrained(embed_path)
-        self.embed = embed
+        embed.from_pretrained(embed_path, device=self.device)
+        self.embed = embed.to(self.device)
         self.logger.log(logging.INFO, "embed loaded.")
 
         gpt = GPT(

--- a/ChatTTS/model/dvae.py
+++ b/ChatTTS/model/dvae.py
@@ -179,8 +179,10 @@ class MelSpectrogramFeatures(torch.nn.Module):
         hop_length=256,
         n_mels=100,
         padding: Literal["center", "same"] = "center",
+        device: torch.device = torch.device('cuda'),
     ):
         super().__init__()
+        self.device = device
         if padding not in ["center", "same"]:
             raise ValueError("Padding must be 'center' or 'same'.")
         self.padding = padding
@@ -197,6 +199,7 @@ class MelSpectrogramFeatures(torch.nn.Module):
         return super().__call__(audio)
 
     def forward(self, audio: torch.Tensor) -> torch.Tensor:
+        audio = audio.to(self.device)
         mel: torch.Tensor = self.mel_spec(audio)
         features = torch.log(torch.clip(mel, min=1e-5))
         return features
@@ -210,6 +213,7 @@ class DVAE(nn.Module):
         vq_config: Optional[dict] = None,
         dim=512,
         coef: Optional[str] = None,
+        device: torch.device = torch.device('cuda'),
     ):
         super().__init__()
         if coef is None:
@@ -227,7 +231,7 @@ class DVAE(nn.Module):
                 nn.Conv1d(dim, dim, 4, 2, 1),
                 nn.GELU(),
             )
-            self.preprocessor_mel = MelSpectrogramFeatures()
+            self.preprocessor_mel = MelSpectrogramFeatures(device=device)
             self.encoder: Optional[DVAEDecoder] = DVAEDecoder(**encoder_config)
 
         self.decoder = DVAEDecoder(**decoder_config)

--- a/ChatTTS/model/dvae.py
+++ b/ChatTTS/model/dvae.py
@@ -179,7 +179,7 @@ class MelSpectrogramFeatures(torch.nn.Module):
         hop_length=256,
         n_mels=100,
         padding: Literal["center", "same"] = "center",
-        device: torch.device = torch.device('cuda'),
+        device: torch.device = torch.device("cuda"),
     ):
         super().__init__()
         self.device = device
@@ -213,7 +213,7 @@ class DVAE(nn.Module):
         vq_config: Optional[dict] = None,
         dim=512,
         coef: Optional[str] = None,
-        device: torch.device = torch.device('cuda'),
+        device: torch.device = torch.device("cuda"),
     ):
         super().__init__()
         if coef is None:

--- a/ChatTTS/model/embed.py
+++ b/ChatTTS/model/embed.py
@@ -34,12 +34,13 @@ class Embed(nn.Module):
         )
 
     @torch.inference_mode()
-    def from_pretrained(self, filename: str):
+    def from_pretrained(self, filename: str, device: torch.device):
         state_dict_tensors = {}
         with safe_open(filename, framework="pt") as f:
             for k in f.keys():
                 state_dict_tensors[k] = f.get_tensor(k)
         self.load_state_dict(state_dict_tensors)
+        self.to(device)
 
     def __call__(
         self, input_ids: torch.Tensor, text_mask: torch.Tensor


### PR DESCRIPTION
This PR addresses RuntimeErrors caused by device mismatches between various components of the model. These errors occur when tensors are on different devices (CPU and CUDA).

Changes made:

1. In `ChatTTS/core.py`:
   - Modified `embed.from_pretrained()` call to include the device parameter.
   - Explicitly moved the embed model to the specified device.
   - Added device parameter to DVAE initialization.

2. In `ChatTTS/model/embed.py`:
   - Updated `from_pretrained()` method to accept a device parameter.
   - Added a `to(device)` call to ensure the model is on the correct device.

3. In `ChatTTS/model/dvae.py`:
   - Added device parameter to `MelSpectrogramFeatures` initialization.
   - Ensured audio tensor is moved to the correct device in the forward method.
   - Added device parameter to DVAE initialization.

These changes ensure that all components (embed model, DVAE, and audio processing) are loaded and used on the same device, resolving RuntimeErrors related to device mismatches.

Related issues: #603 #736

This PR aims to provide a comprehensive solution to device-related issues, improving the overall stability and compatibility of the model across different hardware setups.
