### PR TITLE
Update requirements.txt to include openai

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ WeTextProcessing; sys_platform == 'linux'
 nemo_text_processing; sys_platform == 'linux'
 av
 pydub
+openai


### PR DESCRIPTION
While conducting a fuzz campaign for [Benchify](https://www.benchify.com) I noticed that you appear to be missing an import for OpenAI, which you use in [llm.py](https://github.com/2noise/ChatTTS/blob/8fcc0cd6ae162ff8f2d65a2b355aaafb47d7e9e8/tools/llm/llm.py#L1).  This PR fixes that omission.