### PR TITLE
修复不能读出"啊"和"呃"的bug

### DIFF
--- a/tools/normalizer/zh.py
+++ b/tools/normalizer/zh.py
@@ -4,4 +4,4 @@ from typing import Callable
 def normalizer_zh_tn() -> Callable[[str], str]:
     from tn.chinese.normalizer import Normalizer
 
-    return Normalizer().normalize
+    return Normalizer(remove_interjections=False).normalize


### PR DESCRIPTION
原因找到了，最新版的ChatTTS不能读出“啊”和“呃”这两个字，我之前给这个bug提了个issue #745 
现在原因找到了

WeTextProcessing进行处理时，会默认去除“啊”和“呃”这两个字，但它提供了选项“remove_interjections“，因此只需要在实例化Normalizer时，将remove_interjections设为False，“啊”和“呃”就不会被去除，并且interjections一共就包含“啊”和“呃”这两个字，因此将remove_interjections改为False并不会影响其他字符。

加上“remove_interjections=False”，就能顺利读出“啊”和“呃”这两个字，从而让ChatTTS有别与其他TTS。

但需要注意的是，首次运行WeTextProcessing时，会创建两个fst文件，若要生效，需要删除这两个文件，然后再启动项目，才能生成新的fst文件

![image](https://github.com/user-attachments/assets/7545ed0a-1c06-428c-8601-b9651bbed511)



WeTextProcessing项目指引：

![image](https://github.com/user-attachments/assets/15312c8c-f079-4b06-b1b9-1baa95430816)

![image](https://github.com/user-attachments/assets/69d19bce-3b16-41c5-8185-5b99d1c312f6)

![image](https://github.com/user-attachments/assets/53e319c8-f6a3-4629-b36f-8bf1db720d22)
