### PR TITLE
python 3.12 fails to install requirements, 3.13 not supported.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ pip install --upgrade -r requirements.txt
 
 #### 2. Install from conda
 ```bash
-conda create -n chattts
+conda create -n chattts python=3.11
 conda activate chattts
 pip install -r requirements.txt
 ```


### PR DESCRIPTION
Pinning python version would be really useful for new users trying to struggle through python dependency hell.  

