### PR TITLE
add cache_dir parameter

### DIFF
--- a/ChatTTS/core.py
+++ b/ChatTTS/core.py
@@ -144,9 +144,7 @@ class Chat:
         use_vllm=False,
         experimental: bool = False,
     ) -> bool:
-        download_path = self.download_models(
-            source, force_redownload, custom_path
-        )
+        download_path = self.download_models(source, force_redownload, custom_path)
         if download_path is None:
             return False
         return self._load(

--- a/ChatTTS/core.py
+++ b/ChatTTS/core.py
@@ -84,7 +84,23 @@ class Chat:
                     )
                     return None
         elif source == "huggingface":
-            if cache_dir:
+            if cache_dir is None:
+                hf_home = os.getenv(
+                    "HF_HOME", os.path.expanduser("~/.cache/huggingface")
+                )
+            else:
+                hf_home = cache_dir
+            try:
+                download_path = get_latest_modified_file(
+                    os.path.join(hf_home, "hub/models--2Noise--ChatTTS/snapshots")
+                )
+            except:
+                download_path = None
+            if download_path is None or force_redownload:
+                self.logger.log(
+                    logging.INFO,
+                    f"download from HF: https://huggingface.co/2Noise/ChatTTS",
+                )
                 try:
                     download_path = snapshot_download(
                         repo_id="2Noise/ChatTTS",
@@ -94,28 +110,6 @@ class Chat:
                     )
                 except:
                     download_path = None
-            else:
-                hf_home = os.getenv(
-                    "HF_HOME", os.path.expanduser("~/.cache/huggingface")
-                )
-                try:
-                    download_path = get_latest_modified_file(
-                        os.path.join(hf_home, "hub/models--2Noise--ChatTTS/snapshots")
-                    )
-                except:
-                    download_path = None
-                if download_path is None or force_redownload:
-                    self.logger.log(
-                        logging.INFO,
-                        f"download from HF: https://huggingface.co/2Noise/ChatTTS",
-                    )
-                    try:
-                        download_path = snapshot_download(
-                            repo_id="2Noise/ChatTTS",
-                            allow_patterns=["*.yaml", "*.json", "*.safetensors"],
-                        )
-                    except:
-                        download_path = None
                 else:
                     self.logger.log(
                         logging.INFO,
@@ -134,7 +128,6 @@ class Chat:
 
         return download_path
 
-    # Modified
     def load(
         self,
         source: Literal["huggingface", "local", "custom"] = "local",

--- a/ChatTTS/core.py
+++ b/ChatTTS/core.py
@@ -84,15 +84,13 @@ class Chat:
                     )
                     return None
         elif source == "huggingface":
-            if cache_dir is None:
-                hf_home = os.getenv(
-                    "HF_HOME", os.path.expanduser("~/.cache/huggingface")
-                )
-            else:
-                hf_home = cache_dir
             try:
                 download_path = get_latest_modified_file(
-                    os.path.join(hf_home, "hub/models--2Noise--ChatTTS/snapshots")
+                    os.path.join(os.getenv(
+                        "HF_HOME", os.path.expanduser("~/.cache/huggingface")
+                    ), "hub/models--2Noise--ChatTTS/snapshots")
+                ) if cache_dir is None else get_latest_modified_file(
+                    os.path.join(cache_dir, "models--2Noise--ChatTTS/snapshots")
                 )
             except:
                 download_path = None

--- a/ChatTTS/core.py
+++ b/ChatTTS/core.py
@@ -85,12 +85,19 @@ class Chat:
                     return None
         elif source == "huggingface":
             try:
-                download_path = get_latest_modified_file(
-                    os.path.join(os.getenv(
-                        "HF_HOME", os.path.expanduser("~/.cache/huggingface")
-                    ), "hub/models--2Noise--ChatTTS/snapshots")
-                ) if cache_dir is None else get_latest_modified_file(
-                    os.path.join(cache_dir, "models--2Noise--ChatTTS/snapshots")
+                download_path = (
+                    get_latest_modified_file(
+                        os.path.join(
+                            os.getenv(
+                                "HF_HOME", os.path.expanduser("~/.cache/huggingface")
+                            ),
+                            "hub/models--2Noise--ChatTTS/snapshots",
+                        )
+                    )
+                    if cache_dir is None
+                    else get_latest_modified_file(
+                        os.path.join(cache_dir, "models--2Noise--ChatTTS/snapshots")
+                    )
                 )
             except:
                 download_path = None

--- a/ChatTTS/core.py
+++ b/ChatTTS/core.py
@@ -91,12 +91,14 @@ class Chat:
                         repo_id="2Noise/ChatTTS",
                         allow_patterns=["*.yaml", "*.json", "*.safetensors"],
                         cache_dir=cache_dir,
-                        force_download=force_redownload
+                        force_download=force_redownload,
                     )
                 except:
                     download_path = None
             else:
-                hf_home = os.getenv("HF_HOME", os.path.expanduser("~/.cache/huggingface"))
+                hf_home = os.getenv(
+                    "HF_HOME", os.path.expanduser("~/.cache/huggingface")
+                )
                 try:
                     download_path = get_latest_modified_file(
                         os.path.join(hf_home, "hub/models--2Noise--ChatTTS/snapshots")
@@ -117,7 +119,8 @@ class Chat:
                         download_path = None
                 else:
                     self.logger.log(
-                        logging.INFO, f"load latest snapshot from cache: {download_path}"
+                        logging.INFO,
+                        f"load latest snapshot from cache: {download_path}",
                     )
         elif source == "custom":
             self.logger.log(logging.INFO, f"try to load from local: {custom_path}")
@@ -146,7 +149,9 @@ class Chat:
         experimental: bool = False,
         cache_dir: Optional[str] = None,
     ) -> bool:
-        download_path = self.download_models(source, force_redownload, custom_path, cache_dir)
+        download_path = self.download_models(
+            source, force_redownload, custom_path, cache_dir
+        )
         if download_path is None:
             return False
         return self._load(

--- a/ChatTTS/core.py
+++ b/ChatTTS/core.py
@@ -61,7 +61,6 @@ class Chat:
 
         return not not_finish
 
-    # Modified
     def download_models(
         self,
         source: Literal["huggingface", "local", "custom"] = "local",

--- a/ChatTTS/core.py
+++ b/ChatTTS/core.py
@@ -66,10 +66,9 @@ class Chat:
         source: Literal["huggingface", "local", "custom"] = "local",
         force_redownload=False,
         custom_path: Optional[torch.serialization.FILE_LIKE] = None,
-        cache_dir: Optional[str] = None,
     ) -> Optional[str]:
         if source == "local":
-            download_path = cache_dir if cache_dir else os.getcwd()
+            download_path = custom_path if custom_path is not None else os.getcwd()
             if (
                 not check_all_assets(Path(download_path), self.sha256_map, update=True)
                 or force_redownload
@@ -94,9 +93,9 @@ class Chat:
                             "hub/models--2Noise--ChatTTS/snapshots",
                         )
                     )
-                    if cache_dir is None
+                    if custom_path is None
                     else get_latest_modified_file(
-                        os.path.join(cache_dir, "models--2Noise--ChatTTS/snapshots")
+                        os.path.join(custom_path, "models--2Noise--ChatTTS/snapshots")
                     )
                 )
             except:
@@ -110,7 +109,7 @@ class Chat:
                     download_path = snapshot_download(
                         repo_id="2Noise/ChatTTS",
                         allow_patterns=["*.yaml", "*.json", "*.safetensors"],
-                        cache_dir=cache_dir,
+                        cache_dir=custom_path,
                         force_download=force_redownload,
                     )
                 except:
@@ -144,10 +143,9 @@ class Chat:
         use_flash_attn=False,
         use_vllm=False,
         experimental: bool = False,
-        cache_dir: Optional[str] = None,
     ) -> bool:
         download_path = self.download_models(
-            source, force_redownload, custom_path, cache_dir
+            source, force_redownload, custom_path
         )
         if download_path is None:
             return False

--- a/tools/audio/av.py
+++ b/tools/audio/av.py
@@ -41,11 +41,11 @@ def wav2(i: BytesIO, o: BufferedWriter, format: str):
 
 
 def load_audio(
-        file: Union[str, BytesIO, Path],
-        sr: Optional[int] = None,
-        format: Optional[str] = None,
-        mono=True,
-    ) -> Union[np.ndarray, Tuple[np.ndarray, int]]:
+    file: Union[str, BytesIO, Path],
+    sr: Optional[int] = None,
+    format: Optional[str] = None,
+    mono=True,
+) -> Union[np.ndarray, Tuple[np.ndarray, int]]:
     """
     https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/blob/412a9950a1e371a018c381d1bfb8579c4b0de329/infer/lib/audio.py#L39
     """
@@ -113,7 +113,7 @@ def load_audio(
 
             np.copyto(decoded_audio[..., offset:end_index], frame_data)
             offset += len(frame_data[0])
-    
+
     container.close()
 
     # Truncate the array to the actual size

--- a/tools/audio/av.py
+++ b/tools/audio/av.py
@@ -41,11 +41,11 @@ def wav2(i: BytesIO, o: BufferedWriter, format: str):
 
 
 def load_audio(
-    file: Union[str, BytesIO, Path],
-    sr: Optional[int] = None,
-    format: Optional[str] = None,
-    mono=True,
-) -> Union[np.ndarray, Tuple[np.ndarray, int]]:
+        file: Union[str, BytesIO, Path],
+        sr: Optional[int] = None,
+        format: Optional[str] = None,
+        mono=True,
+    ) -> Union[np.ndarray, Tuple[np.ndarray, int]]:
     """
     https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/blob/412a9950a1e371a018c381d1bfb8579c4b0de329/infer/lib/audio.py#L39
     """
@@ -113,7 +113,7 @@ def load_audio(
 
             np.copyto(decoded_audio[..., offset:end_index], frame_data)
             offset += len(frame_data[0])
-
+    
     container.close()
 
     # Truncate the array to the actual size


### PR DESCRIPTION
Currently, it's the program only allows you to use "huggingface," "local," or "custom" but none allow you to specify a directory where you want to download a file automatically using ```snapshot_download."  This fixes that.

This pull request implements the following:

Here's a brief summary of the different options for handling model files in ChatTTS:

`source="huggingface"`: Downloads models from HuggingFace repo to ~/.cache/huggingface
  * or to cache_dir if specified

`source="local"`: Downloads models from HuggingFace repo to current working directory
  * or to cache_dir if specified

`source="custom"`:
  * No change

## Example Usage:

```python
from ChatTTS import Chat

# Option 1: Using huggingface source with custom cache directory
chat = Chat()
chat.load(
    source="huggingface",
    cache_dir="path/to/your/models",
    device="cuda"
)

# Option 2: Using local source with custom cache directory 
chat = Chat()
chat.load(
    source="local",
    cache_dir="path/to/your/models",
    device="cuda"
)

# Original behavior still works without cache_dir
chat = Chat()
chat.load(
    source="huggingface",  # Will use ~/.cache/huggingface
    device="cuda"
)
```