### PR TITLE
add cache_dir and local_dir parameters

### DIFF
--- a/ChatTTS/core.py
+++ b/ChatTTS/core.py
@@ -61,54 +61,87 @@ class Chat:
 
         return not not_finish
 
+    # Modified
     def download_models(
         self,
         source: Literal["huggingface", "local", "custom"] = "local",
         force_redownload=False,
         custom_path: Optional[torch.serialization.FILE_LIKE] = None,
+        cache_dir: Optional[str] = None,
+        local_dir: Optional[str] = None,
     ) -> Optional[str]:
         if source == "local":
-            download_path = os.getcwd()
-            if (
-                not check_all_assets(Path(download_path), self.sha256_map, update=True)
-                or force_redownload
-            ):
+            download_path = local_dir if local_dir else (cache_dir if cache_dir else os.getcwd())
+            if local_dir:
+                # Skip hash checking when using local_dir
                 with tempfile.TemporaryDirectory() as tmp:
                     download_all_assets(tmpdir=tmp)
-                if not check_all_assets(
-                    Path(download_path), self.sha256_map, update=False
+            else:
+                # Do hash checking for cache_dir or default path
+                if (
+                    not check_all_assets(Path(download_path), self.sha256_map, update=True)
+                    or force_redownload
                 ):
-                    self.logger.error(
-                        "download to local path %s failed.", download_path
-                    )
-                    return None
+                    with tempfile.TemporaryDirectory() as tmp:
+                        download_all_assets(tmpdir=tmp)
+                    if not check_all_assets(
+                        Path(download_path), self.sha256_map, update=False
+                    ):
+                        self.logger.error(
+                            "download to local path %s failed.", download_path
+                        )
+                        return None
+
         elif source == "huggingface":
-            hf_home = os.getenv("HF_HOME", os.path.expanduser("~/.cache/huggingface"))
             try:
-                download_path = get_latest_modified_file(
-                    os.path.join(hf_home, "hub/models--2Noise--ChatTTS/snapshots")
-                )
-            except:
-                download_path = None
-            if download_path is None or force_redownload:
-                self.logger.log(
-                    logging.INFO,
-                    f"download from HF: https://huggingface.co/2Noise/ChatTTS",
-                )
-                try:
+                if local_dir:
+                    # Skip hash checking when using local_dir
                     download_path = snapshot_download(
                         repo_id="2Noise/ChatTTS",
                         allow_patterns=["*.yaml", "*.json", "*.safetensors"],
+                        local_dir=local_dir,
+                        force_download=force_redownload
                     )
-                except:
-                    download_path = None
-            else:
-                self.logger.log(
-                    logging.INFO, f"load latest snapshot from cache: {download_path}"
-                )
-            if download_path is None:
-                self.logger.error("download from huggingface failed.")
-                return None
+                elif cache_dir:
+                    # Download to cache_dir and verify hashes
+                    download_path = snapshot_download(
+                        repo_id="2Noise/ChatTTS",
+                        allow_patterns=["*.yaml", "*.json", "*.safetensors"],
+                        cache_dir=cache_dir,
+                        force_download=force_redownload
+                    )
+                    if not check_all_assets(Path(download_path), self.sha256_map, update=False):
+                        self.logger.error("Model verification failed")
+                        return None
+                else:
+                    # Original behavior for default HF cache
+                    hf_home = os.getenv("HF_HOME", os.path.expanduser("~/.cache/huggingface"))
+                    try:
+                        download_path = get_latest_modified_file(
+                            os.path.join(hf_home, "hub/models--2Noise--ChatTTS/snapshots")
+                        )
+                    except:
+                        download_path = None
+                    if download_path is None or force_redownload:
+                        self.logger.log(
+                            logging.INFO,
+                            f"download from HF: https://huggingface.co/2Noise/ChatTTS",
+                        )
+                        download_path = snapshot_download(
+                            repo_id="2Noise/ChatTTS",
+                            allow_patterns=["*.yaml", "*.json", "*.safetensors"],
+                        )
+                        if not check_all_assets(Path(download_path), self.sha256_map, update=False):
+                            self.logger.error("Model verification failed")
+                            return None
+                    else:
+                        self.logger.log(
+                            logging.INFO, f"load latest snapshot from cache: {download_path}"
+                        )
+            except Exception as e:
+                self.logger.error(f"Failed to download models: {str(e)}")
+                download_path = None
+
         elif source == "custom":
             self.logger.log(logging.INFO, f"try to load from local: {custom_path}")
             if not check_all_assets(Path(custom_path), self.sha256_map, update=False):
@@ -116,8 +149,13 @@ class Chat:
                 return None
             download_path = custom_path
 
+        if download_path is None:
+            self.logger.error("Model download failed")
+            return None
+
         return download_path
 
+    # Modified
     def load(
         self,
         source: Literal["huggingface", "local", "custom"] = "local",
@@ -129,8 +167,10 @@ class Chat:
         use_flash_attn=False,
         use_vllm=False,
         experimental: bool = False,
+        cache_dir: Optional[str] = None,
+        local_dir: Optional[str] = None,
     ) -> bool:
-        download_path = self.download_models(source, force_redownload, custom_path)
+        download_path = self.download_models(source, force_redownload, custom_path, cache_dir, local_dir)
         if download_path is None:
             return False
         return self._load(

--- a/ChatTTS/core.py
+++ b/ChatTTS/core.py
@@ -71,7 +71,9 @@ class Chat:
         local_dir: Optional[str] = None,
     ) -> Optional[str]:
         if source == "local":
-            download_path = local_dir if local_dir else (cache_dir if cache_dir else os.getcwd())
+            download_path = (
+                local_dir if local_dir else (cache_dir if cache_dir else os.getcwd())
+            )
             if local_dir:
                 # Skip hash checking when using local_dir
                 with tempfile.TemporaryDirectory() as tmp:
@@ -79,7 +81,9 @@ class Chat:
             else:
                 # Do hash checking for cache_dir or default path
                 if (
-                    not check_all_assets(Path(download_path), self.sha256_map, update=True)
+                    not check_all_assets(
+                        Path(download_path), self.sha256_map, update=True
+                    )
                     or force_redownload
                 ):
                     with tempfile.TemporaryDirectory() as tmp:
@@ -100,7 +104,7 @@ class Chat:
                         repo_id="2Noise/ChatTTS",
                         allow_patterns=["*.yaml", "*.json", "*.safetensors"],
                         local_dir=local_dir,
-                        force_download=force_redownload
+                        force_download=force_redownload,
                     )
                 elif cache_dir:
                     # Download to cache_dir and verify hashes
@@ -108,17 +112,23 @@ class Chat:
                         repo_id="2Noise/ChatTTS",
                         allow_patterns=["*.yaml", "*.json", "*.safetensors"],
                         cache_dir=cache_dir,
-                        force_download=force_redownload
+                        force_download=force_redownload,
                     )
-                    if not check_all_assets(Path(download_path), self.sha256_map, update=False):
+                    if not check_all_assets(
+                        Path(download_path), self.sha256_map, update=False
+                    ):
                         self.logger.error("Model verification failed")
                         return None
                 else:
                     # Original behavior for default HF cache
-                    hf_home = os.getenv("HF_HOME", os.path.expanduser("~/.cache/huggingface"))
+                    hf_home = os.getenv(
+                        "HF_HOME", os.path.expanduser("~/.cache/huggingface")
+                    )
                     try:
                         download_path = get_latest_modified_file(
-                            os.path.join(hf_home, "hub/models--2Noise--ChatTTS/snapshots")
+                            os.path.join(
+                                hf_home, "hub/models--2Noise--ChatTTS/snapshots"
+                            )
                         )
                     except:
                         download_path = None
@@ -131,12 +141,15 @@ class Chat:
                             repo_id="2Noise/ChatTTS",
                             allow_patterns=["*.yaml", "*.json", "*.safetensors"],
                         )
-                        if not check_all_assets(Path(download_path), self.sha256_map, update=False):
+                        if not check_all_assets(
+                            Path(download_path), self.sha256_map, update=False
+                        ):
                             self.logger.error("Model verification failed")
                             return None
                     else:
                         self.logger.log(
-                            logging.INFO, f"load latest snapshot from cache: {download_path}"
+                            logging.INFO,
+                            f"load latest snapshot from cache: {download_path}",
                         )
             except Exception as e:
                 self.logger.error(f"Failed to download models: {str(e)}")
@@ -170,7 +183,9 @@ class Chat:
         cache_dir: Optional[str] = None,
         local_dir: Optional[str] = None,
     ) -> bool:
-        download_path = self.download_models(source, force_redownload, custom_path, cache_dir, local_dir)
+        download_path = self.download_models(
+            source, force_redownload, custom_path, cache_dir, local_dir
+        )
         if download_path is None:
             return False
         return self._load(

--- a/tools/audio/av.py
+++ b/tools/audio/av.py
@@ -41,11 +41,11 @@ def wav2(i: BytesIO, o: BufferedWriter, format: str):
 
 
 def load_audio(
-        file: Union[str, BytesIO, Path],
-        sr: Optional[int] = None,
-        format: Optional[str] = None,
-        mono=True,
-    ) -> Union[np.ndarray, Tuple[np.ndarray, int]]:
+    file: Union[str, BytesIO, Path],
+    sr: Optional[int] = None,
+    format: Optional[str] = None,
+    mono=True,
+) -> Union[np.ndarray, Tuple[np.ndarray, int]]:
     """
     https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/blob/412a9950a1e371a018c381d1bfb8579c4b0de329/infer/lib/audio.py#L39
     """
@@ -113,7 +113,7 @@ def load_audio(
 
             np.copyto(decoded_audio[..., offset:end_index], frame_data)
             offset += len(frame_data[0])
-    
+
     container.close()
 
     # Truncate the array to the actual size


### PR DESCRIPTION
This pull request is related (but not identical) to https://github.com/2noise/ChatTTS/pull/863

It builds upon the other pull request adding a ```local_dir``` parameter, allowing the download of the repository NOT IN BLOB form:

## Summary

| Source | Parameters | Behavior | File Structure | Hash Verification |
|--------|------------|----------|----------------|------------------|
| `"huggingface"` | (default) | Downloads to ~/.cache/huggingface | Cache structure | Yes |
| `"huggingface"` | cache_dir="path" | Downloads to specified path | Cache structure | Yes |
| `"huggingface"` | local_dir="path" | Downloads to specified path | Original repo structure | No |
| `"local"` | (default) | Downloads to current directory | Cache structure | Yes |
| `"local"` | cache_dir="path" | Downloads to specified path | Cache structure | Yes |
| `"local"` | local_dir="path" | Downloads to specified path | Original repo structure | No |
| `"custom"` | custom_path="path" | Uses existing files | As provided | Yes |
| `"custom"` | custom_path + cache_dir | cache_dir ignored | As provided | Yes |
| `"custom"` | custom_path + local_dir | local_dir ignored | As provided | Yes |
