### PR TITLE
Add local dir parameter

### DIFF
--- a/ChatTTS/core.py
+++ b/ChatTTS/core.py
@@ -27,6 +27,7 @@ from .utils import logger as utils_logger
 
 from .norm import Normalizer
 
+
 class Chat:
     def __init__(self, logger=logging.getLogger(__name__)):
         self.logger = logger
@@ -62,104 +63,134 @@ class Chat:
         return not not_finish
 
     def download_models(
-       self,
-       source: Literal["huggingface", "local", "custom"] = "local",
-       force_redownload=False,
-       custom_path: Optional[torch.serialization.FILE_LIKE] = None,
-       cache_dir: Optional[str] = None,
-       local_dir: Optional[str] = None,
+        self,
+        source: Literal["huggingface", "local", "custom"] = "local",
+        force_redownload=False,
+        custom_path: Optional[torch.serialization.FILE_LIKE] = None,
+        cache_dir: Optional[str] = None,
+        local_dir: Optional[str] = None,
     ) -> Optional[str]:
-       if source == "local":
-           download_path = local_dir if local_dir else (cache_dir if cache_dir else os.getcwd())
-           if (
-               not check_all_assets(Path(download_path), self.sha256_map, update=True)
-               or force_redownload
-           ):
-               with tempfile.TemporaryDirectory() as tmp:
-                   download_all_assets(tmpdir=tmp, homedir=download_path)
-               if not check_all_assets(
-                   Path(download_path), self.sha256_map, update=False
-               ):
-                   self.logger.error(
-                       "download to local path %s failed.", download_path
-                   )
-                   return None
+        if source == "local":
+            download_path = (
+                local_dir if local_dir else (cache_dir if cache_dir else os.getcwd())
+            )
+            if (
+                not check_all_assets(Path(download_path), self.sha256_map, update=True)
+                or force_redownload
+            ):
+                with tempfile.TemporaryDirectory() as tmp:
+                    download_all_assets(tmpdir=tmp, homedir=download_path)
+                if not check_all_assets(
+                    Path(download_path), self.sha256_map, update=False
+                ):
+                    self.logger.error(
+                        "download to local path %s failed.", download_path
+                    )
+                    return None
 
-       elif source == "huggingface":
-           try:
-               if local_dir:
-                   download_path = snapshot_download(
-                       repo_id="2Noise/ChatTTS",
-                       allow_patterns=["*.yaml", "*.json", "*.safetensors", "spk_stat.pt", "tokenizer.pt"],
-                       local_dir=local_dir,
-                       force_download=force_redownload
-                   )
-                   if not check_all_assets(Path(download_path), self.sha256_map, update=False):
-                       self.logger.error("Model verification failed")
-                       return None
-               elif cache_dir:
-                   download_path = snapshot_download(
-                       repo_id="2Noise/ChatTTS",
-                       allow_patterns=["*.yaml", "*.json", "*.safetensors", "spk_stat.pt", "tokenizer.pt"],
-                       cache_dir=cache_dir,
-                       force_download=force_redownload
-                   )
-                   if not check_all_assets(Path(download_path), self.sha256_map, update=False):
-                       self.logger.error("Model verification failed")
-                       return None
-               else:
-                   try:
-                       download_path = (
-                           get_latest_modified_file(
-                               os.path.join(
-                                   os.getenv(
-                                       "HF_HOME", os.path.expanduser("~/.cache/huggingface")
-                                   ),
-                                   "hub/models--2Noise--ChatTTS/snapshots",
-                               )
-                           )
-                           if custom_path is None
-                           else get_latest_modified_file(
-                               os.path.join(custom_path, "models--2Noise--ChatTTS/snapshots")
-                           )
-                       )
-                   except:
-                       download_path = None
-                   if download_path is None or force_redownload:
-                       self.logger.log(
-                           logging.INFO,
-                           f"download from HF: https://huggingface.co/2Noise/ChatTTS",
-                       )
-                       try:
-                           download_path = snapshot_download(
-                               repo_id="2Noise/ChatTTS",
-                               allow_patterns=["*.yaml", "*.json", "*.safetensors", "spk_stat.pt", "tokenizer.pt"],
-                           )
-                           if not check_all_assets(Path(download_path), self.sha256_map, update=False):
-                               self.logger.error("Model verification failed")
-                               return None
-                       except:
-                           download_path = None
-                       else:
-                           self.logger.log(
-                               logging.INFO, f"load latest snapshot from cache: {download_path}"
-                           )
-           except Exception as e:
-               self.logger.error(f"Failed to download models: {str(e)}")
-               download_path = None
+        elif source == "huggingface":
+            try:
+                if local_dir:
+                    download_path = snapshot_download(
+                        repo_id="2Noise/ChatTTS",
+                        allow_patterns=[
+                            "*.yaml",
+                            "*.json",
+                            "*.safetensors",
+                            "spk_stat.pt",
+                            "tokenizer.pt",
+                        ],
+                        local_dir=local_dir,
+                        force_download=force_redownload,
+                    )
+                    if not check_all_assets(
+                        Path(download_path), self.sha256_map, update=False
+                    ):
+                        self.logger.error("Model verification failed")
+                        return None
+                elif cache_dir:
+                    download_path = snapshot_download(
+                        repo_id="2Noise/ChatTTS",
+                        allow_patterns=[
+                            "*.yaml",
+                            "*.json",
+                            "*.safetensors",
+                            "spk_stat.pt",
+                            "tokenizer.pt",
+                        ],
+                        cache_dir=cache_dir,
+                        force_download=force_redownload,
+                    )
+                    if not check_all_assets(
+                        Path(download_path), self.sha256_map, update=False
+                    ):
+                        self.logger.error("Model verification failed")
+                        return None
+                else:
+                    try:
+                        download_path = (
+                            get_latest_modified_file(
+                                os.path.join(
+                                    os.getenv(
+                                        "HF_HOME",
+                                        os.path.expanduser("~/.cache/huggingface"),
+                                    ),
+                                    "hub/models--2Noise--ChatTTS/snapshots",
+                                )
+                            )
+                            if custom_path is None
+                            else get_latest_modified_file(
+                                os.path.join(
+                                    custom_path, "models--2Noise--ChatTTS/snapshots"
+                                )
+                            )
+                        )
+                    except:
+                        download_path = None
+                    if download_path is None or force_redownload:
+                        self.logger.log(
+                            logging.INFO,
+                            f"download from HF: https://huggingface.co/2Noise/ChatTTS",
+                        )
+                        try:
+                            download_path = snapshot_download(
+                                repo_id="2Noise/ChatTTS",
+                                allow_patterns=[
+                                    "*.yaml",
+                                    "*.json",
+                                    "*.safetensors",
+                                    "spk_stat.pt",
+                                    "tokenizer.pt",
+                                ],
+                            )
+                            if not check_all_assets(
+                                Path(download_path), self.sha256_map, update=False
+                            ):
+                                self.logger.error("Model verification failed")
+                                return None
+                        except:
+                            download_path = None
+                        else:
+                            self.logger.log(
+                                logging.INFO,
+                                f"load latest snapshot from cache: {download_path}",
+                            )
+            except Exception as e:
+                self.logger.error(f"Failed to download models: {str(e)}")
+                download_path = None
 
-       elif source == "custom":
-           self.logger.log(logging.INFO, f"try to load from local: {custom_path}")
-           if not check_all_assets(Path(custom_path), self.sha256_map, update=False):
-               self.logger.error("check models in custom path %s failed.", custom_path)
-               return None
-           download_path = custom_path
+        elif source == "custom":
+            self.logger.log(logging.INFO, f"try to load from local: {custom_path}")
+            if not check_all_assets(Path(custom_path), self.sha256_map, update=False):
+                self.logger.error("check models in custom path %s failed.", custom_path)
+                return None
+            download_path = custom_path
 
-       if download_path is None:
-           self.logger.error("Model download failed")
-           return None
+        if download_path is None:
+            self.logger.error("Model download failed")
+            return None
 
-       return download_path
+        return download_path
 
     def load(
         self,
@@ -175,7 +206,9 @@ class Chat:
         cache_dir: Optional[str] = None,
         local_dir: Optional[str] = None,
     ) -> bool:
-        download_path = self.download_models(source, force_redownload, custom_path, cache_dir, local_dir)
+        download_path = self.download_models(
+            source, force_redownload, custom_path, cache_dir, local_dir
+        )
         if download_path is None:
             return False
         return self._load(

--- a/ChatTTS/core.py
+++ b/ChatTTS/core.py
@@ -62,105 +62,104 @@ class Chat:
         return not not_finish
 
     def download_models(
-        self,
-        source: Literal["huggingface", "local", "custom"] = "local",
-        force_redownload=False,
-        custom_path: Optional[torch.serialization.FILE_LIKE] = None,
-        cache_dir: Optional[str] = None,
-        local_dir: Optional[str] = None,
+       self,
+       source: Literal["huggingface", "local", "custom"] = "local",
+       force_redownload=False,
+       custom_path: Optional[torch.serialization.FILE_LIKE] = None,
+       cache_dir: Optional[str] = None,
+       local_dir: Optional[str] = None,
     ) -> Optional[str]:
-        if source == "local":
-            download_path = local_dir if local_dir else (cache_dir if cache_dir else os.getcwd())
-            if local_dir:
-                with tempfile.TemporaryDirectory() as tmp:
-                    download_all_assets(tmpdir=tmp, homedir=download_path)
-            else:
-                if (
-                    not check_all_assets(Path(download_path), self.sha256_map, update=True)
-                    or force_redownload
-                ):
-                    with tempfile.TemporaryDirectory() as tmp:
-                        download_all_assets(tmpdir=tmp, homedir=download_path)
-                    if not check_all_assets(
-                        Path(download_path), self.sha256_map, update=False
-                    ):
-                        self.logger.error(
-                            "download to local path %s failed.", download_path
-                        )
-                        return None
+       if source == "local":
+           download_path = local_dir if local_dir else (cache_dir if cache_dir else os.getcwd())
+           if (
+               not check_all_assets(Path(download_path), self.sha256_map, update=True)
+               or force_redownload
+           ):
+               with tempfile.TemporaryDirectory() as tmp:
+                   download_all_assets(tmpdir=tmp, homedir=download_path)
+               if not check_all_assets(
+                   Path(download_path), self.sha256_map, update=False
+               ):
+                   self.logger.error(
+                       "download to local path %s failed.", download_path
+                   )
+                   return None
 
-        elif source == "huggingface":
-            try:
-                if local_dir:
-                    download_path = snapshot_download(
-                        repo_id="2Noise/ChatTTS",
-                        allow_patterns=["*.yaml", "*.json", "*.safetensors"],
-                        local_dir=local_dir,
-                        force_download=force_redownload
-                    )
-                elif cache_dir:
-                    download_path = snapshot_download(
-                        repo_id="2Noise/ChatTTS",
-                        allow_patterns=["*.yaml", "*.json", "*.safetensors"],
-                        cache_dir=cache_dir,
-                        force_download=force_redownload
-                    )
-                    if not check_all_assets(Path(download_path), self.sha256_map, update=False):
-                        self.logger.error("Model verification failed")
-                        return None
-                else:
-                    try:
-                        download_path = (
-                            get_latest_modified_file(
-                                os.path.join(
-                                    os.getenv(
-                                        "HF_HOME", os.path.expanduser("~/.cache/huggingface")
-                                    ),
-                                    "hub/models--2Noise--ChatTTS/snapshots",
-                                )
-                            )
-                            if custom_path is None
-                            else get_latest_modified_file(
-                                os.path.join(custom_path, "models--2Noise--ChatTTS/snapshots")
-                            )
-                        )
-                    except:
-                        download_path = None
-                    if download_path is None or force_redownload:
-                        self.logger.log(
-                            logging.INFO,
-                            f"download from HF: https://huggingface.co/2Noise/ChatTTS",
-                        )
-                        try:
-                            download_path = snapshot_download(
-                                repo_id="2Noise/ChatTTS",
-                                allow_patterns=["*.yaml", "*.json", "*.safetensors"],
-                            )
-                            if not check_all_assets(Path(download_path), self.sha256_map, update=False):
-                                self.logger.error("Model verification failed")
-                                return None
-                        except:
-                            download_path = None
-                        else:
-                            self.logger.log(
-                                logging.INFO, f"load latest snapshot from cache: {download_path}"
-                            )
-            except Exception as e:
-                self.logger.error(f"Failed to download models: {str(e)}")
-                download_path = None
+       elif source == "huggingface":
+           try:
+               if local_dir:
+                   download_path = snapshot_download(
+                       repo_id="2Noise/ChatTTS",
+                       allow_patterns=["*.yaml", "*.json", "*.safetensors", "spk_stat.pt", "tokenizer.pt"],
+                       local_dir=local_dir,
+                       force_download=force_redownload
+                   )
+                   if not check_all_assets(Path(download_path), self.sha256_map, update=False):
+                       self.logger.error("Model verification failed")
+                       return None
+               elif cache_dir:
+                   download_path = snapshot_download(
+                       repo_id="2Noise/ChatTTS",
+                       allow_patterns=["*.yaml", "*.json", "*.safetensors", "spk_stat.pt", "tokenizer.pt"],
+                       cache_dir=cache_dir,
+                       force_download=force_redownload
+                   )
+                   if not check_all_assets(Path(download_path), self.sha256_map, update=False):
+                       self.logger.error("Model verification failed")
+                       return None
+               else:
+                   try:
+                       download_path = (
+                           get_latest_modified_file(
+                               os.path.join(
+                                   os.getenv(
+                                       "HF_HOME", os.path.expanduser("~/.cache/huggingface")
+                                   ),
+                                   "hub/models--2Noise--ChatTTS/snapshots",
+                               )
+                           )
+                           if custom_path is None
+                           else get_latest_modified_file(
+                               os.path.join(custom_path, "models--2Noise--ChatTTS/snapshots")
+                           )
+                       )
+                   except:
+                       download_path = None
+                   if download_path is None or force_redownload:
+                       self.logger.log(
+                           logging.INFO,
+                           f"download from HF: https://huggingface.co/2Noise/ChatTTS",
+                       )
+                       try:
+                           download_path = snapshot_download(
+                               repo_id="2Noise/ChatTTS",
+                               allow_patterns=["*.yaml", "*.json", "*.safetensors", "spk_stat.pt", "tokenizer.pt"],
+                           )
+                           if not check_all_assets(Path(download_path), self.sha256_map, update=False):
+                               self.logger.error("Model verification failed")
+                               return None
+                       except:
+                           download_path = None
+                       else:
+                           self.logger.log(
+                               logging.INFO, f"load latest snapshot from cache: {download_path}"
+                           )
+           except Exception as e:
+               self.logger.error(f"Failed to download models: {str(e)}")
+               download_path = None
 
-        elif source == "custom":
-            self.logger.log(logging.INFO, f"try to load from local: {custom_path}")
-            if not check_all_assets(Path(custom_path), self.sha256_map, update=False):
-                self.logger.error("check models in custom path %s failed.", custom_path)
-                return None
-            download_path = custom_path
+       elif source == "custom":
+           self.logger.log(logging.INFO, f"try to load from local: {custom_path}")
+           if not check_all_assets(Path(custom_path), self.sha256_map, update=False):
+               self.logger.error("check models in custom path %s failed.", custom_path)
+               return None
+           download_path = custom_path
 
-        if download_path is None:
-            self.logger.error("Model download failed")
-            return None
+       if download_path is None:
+           self.logger.error("Model download failed")
+           return None
 
-        return download_path
+       return download_path
 
     def load(
         self,


### PR DESCRIPTION
This PR adds a new `local_dir` parameter to provide more flexible control over model downloads.
  > A lot of people like to actually see the native files and work with them that way rather than HF's weird "cache" structure and naming.

## Key Changes
- Added `local_dir` parameter to both `load()` and `download_models()` methods
- When specified, downloads preserve repository structure in the target directory
- Added precedence handling: `local_dir` takes priority over other download location parameters

## Usage Example
```python
# Download to specific directory, maintaining repo structure
chat.load(source="huggingface", local_dir="path/to/dir")

# Download to specific directory with local source
chat.load(source="local", local_dir="path/to/dir")
```

# Download Configuration Guide

The `source` parameter along with `cache_dir` and `local_dir` control how and where model files are downloaded:

## Source: "huggingface"
Downloads directly from the Hugging Face repository:

| Parameters | Behavior | Repo Structure? |
|------------|----------|-----------------|
| (default) | Downloads to ~/.cache/huggingface using HF's cache system | No |
| cache_dir="path" | Downloads to specified path using HF's cache system | No |
| local_dir="path" | Downloads to specified path preserving repository structure | Yes |

## Source: "local" 
Downloads from GitHub releases instead of Hugging Face:

| Parameters | Behavior | Repo Structure? |
|------------|----------|-----------------|
| (default) | Downloads to current directory | No |
| cache_dir="path" | Downloads to specified path | No |
| local_dir="path" | Downloads to specified path preserving repository structure | Yes |

## Source: "custom"
Uses existing files from a specified path:

| Parameters | Behavior | Repo Structure? |
|------------|----------|-----------------|
| custom_path | Uses existing files at the specified path | n/a |
| +cache_dir | cache_dir parameter is ignored | n/a |
| +local_dir | local_dir parameter is ignored | n/a |

## Repository Structure
When "Repo Structure?" is:
- Yes: Files are downloaded maintaining the original repository's directory structure
- No: Files are downloaded using a flattened or cache-specific structure
- n/a: Uses files exactly as they exist in the custom path

## Parameter Precedence and Usage Examples

* Parameter precedence (highest to lowest):
 * `local_dir` (if specified, takes precedence over all other parameters)
 * `cache_dir` (used if local_dir is not specified)
 * Default location (used if neither local_dir nor cache_dir specified):
   * ~/.cache/huggingface (when source="huggingface")
   * Current directory (when source="local")