### PR TITLE
fix: replace 6 bare except clauses with except Exception

### DIFF
--- a/ChatTTS/core.py
+++ b/ChatTTS/core.py
@@ -100,7 +100,7 @@ class Chat:
                         os.path.join(custom_path, "models--2Noise--ChatTTS/snapshots")
                     )
                 )
-            except:
+            except Exception:
                 download_path = None
             if download_path is None or force_redownload:
                 self.logger.log(
@@ -114,7 +114,7 @@ class Chat:
                         cache_dir=custom_path,
                         force_download=force_redownload,
                     )
-                except:
+                except Exception:
                     download_path = None
                 else:
                     self.logger.log(

--- a/ChatTTS/model/gpt.py
+++ b/ChatTTS/model/gpt.py
@@ -193,7 +193,7 @@ class GPT(nn.Module):
                     )
                     try:
                         max_cache_length = past_key_values.get_max_cache_shape()
-                    except:
+                    except Exception:
                         max_cache_length = (
                             past_key_values.get_max_length()
                         )  # deprecated in transformers 4.48

--- a/ChatTTS/model/velocity/configs.py
+++ b/ChatTTS/model/velocity/configs.py
@@ -12,7 +12,6 @@ import argparse
 import dataclasses
 from dataclasses import dataclass
 
-
 logger = init_logger(__name__)
 
 _GB = 1 << 30

--- a/ChatTTS/model/velocity/llama.py
+++ b/ChatTTS/model/velocity/llama.py
@@ -21,6 +21,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Inference-only LLaMA model compatible with HuggingFace weights."""
+
 from typing import Any, Dict, List, Optional, Tuple
 
 import torch

--- a/ChatTTS/model/velocity/llm_engine.py
+++ b/ChatTTS/model/velocity/llm_engine.py
@@ -741,7 +741,7 @@ class LLMEngine:
 
     def _decode_sequence(self, seq: Sequence, prms: SamplingParams) -> None:
         """Decodes the new token for a sequence."""
-        (new_tokens, new_output_text, prefix_offset, read_offset) = (
+        new_tokens, new_output_text, prefix_offset, read_offset = (
             detokenize_incrementally(
                 self.tokenizer,
                 all_input_ids=seq.get_token_ids(),

--- a/ChatTTS/model/velocity/model_runner.py
+++ b/ChatTTS/model/velocity/model_runner.py
@@ -360,11 +360,11 @@ class ModelRunner:
             is_prompt = seq_group_metadata_list[0].is_prompt
             # Prepare input tensors.
             if is_prompt:
-                (input_tokens, input_positions, input_metadata, prompt_lens) = (
+                input_tokens, input_positions, input_metadata, prompt_lens = (
                     self._prepare_prompt(seq_group_metadata_list)
                 )
             else:
-                (input_tokens, input_positions, input_metadata) = self._prepare_decode(
+                input_tokens, input_positions, input_metadata = self._prepare_decode(
                     seq_group_metadata_list
                 )
                 prompt_lens = []

--- a/examples/api/main.py
+++ b/examples/api/main.py
@@ -6,7 +6,6 @@ import zipfile
 from fastapi import FastAPI
 from fastapi.responses import StreamingResponse
 
-
 if sys.platform == "darwin":
     os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
 

--- a/examples/onnx/modeling_llama.py
+++ b/examples/onnx/modeling_llama.py
@@ -21,6 +21,7 @@
 PyTorch LLaMA model.
 Copied from https://github.com/sophgo/LLM-TPU/blob/main/models/Llama2/compile/files/llama-2-7b-chat-hf/modeling_llama.py
 """
+
 import math
 from typing import List, Optional, Tuple, Union
 
@@ -44,7 +45,6 @@ from transformers.utils import (
     replace_return_docstrings,
 )
 from transformers.models.llama.configuration_llama import LlamaConfig
-
 
 logger = logging.get_logger(__name__)
 

--- a/examples/web/funcs.py
+++ b/examples/web/funcs.py
@@ -77,7 +77,7 @@ def load_chat(cust_path: Optional[str], coef: Optional[str], enable_cache=True) 
             chat.normalizer.register("en", normalizer_en_nemo_text())
         except ValueError as e:
             logger.error(e)
-        except:
+        except Exception:
             logger.warning("Package nemo_text_processing not found!")
             logger.warning(
                 "Run: conda install -c conda-forge pynini=2.1.5 && pip install nemo_text_processing",
@@ -86,7 +86,7 @@ def load_chat(cust_path: Optional[str], coef: Optional[str], enable_cache=True) 
             chat.normalizer.register("zh", normalizer_zh_tn())
         except ValueError as e:
             logger.error(e)
-        except:
+        except Exception:
             logger.warning("Package WeTextProcessing not found!")
             logger.warning(
                 "Run: conda install -c conda-forge pynini=2.1.5 && pip install WeTextProcessing",

--- a/tests/#655.py
+++ b/tests/#655.py
@@ -21,7 +21,7 @@ chat = ChatTTS.Chat(logger)
 chat.load(compile=False, source="huggingface")  # Set to True for better performance
 try:
     chat.normalizer.register("en", normalizer_en_nemo_text())
-except:
+except Exception:
     logger.warning("Package nemo_text_processing not found!")
 
 rand_spk = chat.sample_random_speaker()

--- a/tools/audio/av.py
+++ b/tools/audio/av.py
@@ -7,7 +7,6 @@ from av.audio.frame import AudioFrame
 from av.audio.resampler import AudioResampler
 import numpy as np
 
-
 video_format_dict: Dict[str, str] = {
     "m4a": "mp4",
 }


### PR DESCRIPTION
## What
Replace 6 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors. Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.