### PR TITLE
docs(cn): fix basic usage example to match English README

### DIFF
--- a/ChatTTS/model/velocity/configs.py
+++ b/ChatTTS/model/velocity/configs.py
@@ -12,7 +12,6 @@ import argparse
 import dataclasses
 from dataclasses import dataclass
 
-
 logger = init_logger(__name__)
 
 _GB = 1 << 30

--- a/ChatTTS/model/velocity/llama.py
+++ b/ChatTTS/model/velocity/llama.py
@@ -21,6 +21,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Inference-only LLaMA model compatible with HuggingFace weights."""
+
 from typing import Any, Dict, List, Optional, Tuple
 
 import torch

--- a/ChatTTS/model/velocity/llm_engine.py
+++ b/ChatTTS/model/velocity/llm_engine.py
@@ -741,7 +741,7 @@ class LLMEngine:
 
     def _decode_sequence(self, seq: Sequence, prms: SamplingParams) -> None:
         """Decodes the new token for a sequence."""
-        (new_tokens, new_output_text, prefix_offset, read_offset) = (
+        new_tokens, new_output_text, prefix_offset, read_offset = (
             detokenize_incrementally(
                 self.tokenizer,
                 all_input_ids=seq.get_token_ids(),

--- a/ChatTTS/model/velocity/model_runner.py
+++ b/ChatTTS/model/velocity/model_runner.py
@@ -360,11 +360,11 @@ class ModelRunner:
             is_prompt = seq_group_metadata_list[0].is_prompt
             # Prepare input tensors.
             if is_prompt:
-                (input_tokens, input_positions, input_metadata, prompt_lens) = (
+                input_tokens, input_positions, input_metadata, prompt_lens = (
                     self._prepare_prompt(seq_group_metadata_list)
                 )
             else:
-                (input_tokens, input_positions, input_metadata) = self._prepare_decode(
+                input_tokens, input_positions, input_metadata = self._prepare_decode(
                     seq_group_metadata_list
                 )
                 prompt_lens = []

--- a/docs/cn/README.md
+++ b/docs/cn/README.md
@@ -187,7 +187,15 @@ texts = ["PUT YOUR 1st TEXT HERE", "PUT YOUR 2nd TEXT HERE"]
 
 wavs = chat.infer(texts)
 
-torchaudio.save("output1.wav", torch.from_numpy(wavs[0]), 24000)
+for i in range(len(wavs)):
+    """
+    在某些版本的 torchaudio 中，第一行能运行，
+    但在另一些版本中，则需要使用第二行。
+    """
+    try:
+        torchaudio.save(f"basic_output{i}.wav", torch.from_numpy(wavs[i]).unsqueeze(0), 24000)
+    except:
+        torchaudio.save(f"basic_output{i}.wav", torch.from_numpy(wavs[i]), 24000)
 ```
 
 ### 进阶用法

--- a/examples/api/main.py
+++ b/examples/api/main.py
@@ -6,7 +6,6 @@ import zipfile
 from fastapi import FastAPI
 from fastapi.responses import StreamingResponse
 
-
 if sys.platform == "darwin":
     os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
 

--- a/examples/onnx/modeling_llama.py
+++ b/examples/onnx/modeling_llama.py
@@ -21,6 +21,7 @@
 PyTorch LLaMA model.
 Copied from https://github.com/sophgo/LLM-TPU/blob/main/models/Llama2/compile/files/llama-2-7b-chat-hf/modeling_llama.py
 """
+
 import math
 from typing import List, Optional, Tuple, Union
 
@@ -44,7 +45,6 @@ from transformers.utils import (
     replace_return_docstrings,
 )
 from transformers.models.llama.configuration_llama import LlamaConfig
-
 
 logger = logging.get_logger(__name__)
 

--- a/tools/audio/av.py
+++ b/tools/audio/av.py
@@ -7,7 +7,6 @@ from av.audio.frame import AudioFrame
 from av.audio.resampler import AudioResampler
 import numpy as np
 
-
 video_format_dict: Dict[str, str] = {
     "m4a": "mp4",
 }


### PR DESCRIPTION
## Summary

Fixes #866

The Chinese README (`docs/cn/README.md`) basic usage code example was out of sync with the English README:

1. Only saved the first generated wav (`wavs[0]`) instead of all wavs in a loop
2. Missing `try/except` for torchaudio version compatibility (`unsqueeze(0)` needed in some versions)

## Changes

- `docs/cn/README.md`: Updated basic usage code to loop over all generated wavs with torchaudio version compatibility handling, matching the English README

## Verification

Compared with the English README to confirm the fix matches.