### PR TITLE
fix: guard against empty choices and message=None in LLM response

### DIFF
--- a/tools/llm/llm.py
+++ b/tools/llm/llm.py
@@ -71,4 +71,6 @@ class ChatOpenAI:
             temperature=temperature,
             **kwargs
         )
+        if not completion.choices or completion.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return completion.choices[0].message.content


### PR DESCRIPTION
## Problem

In `tools/llm/llm.py`, the LLM response is accessed without checking if `choices` is empty or `message` is `None`:

```python
return completion.choices[0].message.content
```

This raises `IndexError` (empty choices) or `AttributeError` (message=None on filtered responses).

## Fix

```python
if not completion.choices or completion.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
return completion.choices[0].message.content
```

**2 lines added, 0 deleted.**

Detected by [pact](https://github.com/qizwiz/pact) static analysis.